### PR TITLE
feat/m0: annotations view, library, PDF viewer, editor extensions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(xargs grep *)",
       "Bash(cargo build *)",
       "Bash(npm run *)",
-      "Bash(npx tsc *)"
+      "Bash(npx tsc *)",
+      "Bash(cargo check *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,16 @@
 {
   "permissions": {
     "allow": [
-      "Bash(npm install *)"
+      "Bash(npm install *)",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(npx vue-tsc *)",
+      "Bash(git push *)",
+      "Bash(git commit *)",
+      "Bash(xargs grep *)",
+      "Bash(cargo build *)",
+      "Bash(npm run *)",
+      "Bash(npx tsc *)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,190 @@
+# CLAUDE.md — Quire project context for future sessions
+
+This file exists so you can pick up exactly where we left off without needing conversation history. Read it before touching anything. The codebase is the ground truth for current state; this file is the ground truth for *why*.
+
+---
+
+## What Quire is and why it exists
+
+Quire is a desktop writing environment for academic researchers. The name is deliberate: *a quire* is the unit of folded leaves that makes a book — the thing before the thing is bound.
+
+It was born from a specific, documented pain session: writing a paper on allergen labelling in packaged foods. During a single editorial session, the author had to:
+
+- Open an annotated DOCX a supervisor had returned
+- Cross-reference citation numbers across 7 PDFs
+- Switch between Zotero, a browser, Overleaf, and a terminal
+- Recover a figure from an old git commit because it had been accidentally deleted
+- Look up an ORCID manually
+- Realise mid-draft that two citations had been numbered wrong
+
+**Eight tool switches to write three paragraphs.** That session is the user story. Every feature in Quire traces back to one of those switches.
+
+The core insight is that **existing tools are built around claims management, not narration**. Zotero manages a reference library. Overleaf manages a LaTeX document. Obsidian manages a knowledge graph. None of them understand the act of writing a sentence that makes a claim, points at a source, and needs to be traceable to a page in that source. Quire is built around that act as the atomic unit.
+
+---
+
+## The philosophy
+
+**Narrative-first, not claim-first.** Researchers write arguments in prose. The tools should make the prose surface the primary environment, with everything else (references, annotations, source PDFs, export) reachable without leaving. A citation in Quire is an inline object in the editor — not a footnote database entry you link to, not a LaTeX command you type blind.
+
+**Local-first, file-system native.** Documents are `.qmd` files. The bibliography is a `.bib` file at `~/.quire/references.bib`. Everything lives on disk in standard formats that work without Quire installed. There is no Quire account, no cloud sync, no proprietary format.
+
+**Single source of truth for references.** All projects share `~/.quire/references.bib`. You curate one library, not one per project. Per-project override is possible (a local `.bib` in the same directory takes precedence), but the global file is the default.
+
+**The workbench is the missing layer.** Between "I have annotations from 4 papers" and "I am writing a paragraph that synthesises them" there is a cognitive step that every tool currently punts to the researcher's head or a scratch document. Quire's Workbench view makes that step explicit and spatial: annotation blocks from your sources, organised against your draft outline, with source provenance on every block.
+
+---
+
+## Where we are: M0 complete
+
+M0 is done and working. The branch is `feat/m0`, PR exists to `main`. What's shipped:
+
+### Real editor
+- Tiptap (ProseMirror) WYSIWYG editor in `WriteView.vue`
+- Document content is `.qmd` (Quarto Markdown) with YAML frontmatter parsed by the Rust backend
+- Georgia serif body, system-ui chrome — mirrors the exact aesthetic of the placeholder mockups
+
+### Citations as first-class editor objects
+- `CitationNode` — a custom Tiptap inline atom node that stores `citeKey` + `displayIndex`
+- Rendered as a blue `[N]` superscript by `CitationNodeView.vue` (Vue NodeView)
+- Hover → frosted-glass tooltip with title, authors, abstract excerpt (no panel opens)
+- Click → side panel slides in with full source detail
+- `[?]` in orange if the `citeKey` has no matching entry in the loaded `.bib`
+
+### `@` citation autocomplete
+- Type `@` anywhere in the editor → Overleaf-style dropdown appears
+- Searches the loaded `.bib` by key, title, or author as you type
+- ↑↓ navigate, Enter or click to insert; sequential `[N]` auto-assigned
+- Implemented via `@tiptap/suggestion` + `CitationSuggest.ts` extension
+
+### Global bibliography
+- `~/.quire/references.bib` seeded on first launch with 4 sample entries (Popova 2022, FDA 2021, Hadley & King 2019, FSSAI 2023 — all from the allergen paper session)
+- Rust backend has a hand-rolled `.bib` parser (no crates — handles braced/quoted/nested values, multi-author fields)
+- Commands: `get_global_bib`, `save_global_bib`, `get_global_bib_raw`, `find_bib_for_document`
+
+### File operations
+- Open / Save / Save As via `tauri-plugin-dialog`
+- YAML frontmatter written on save (title, authors, date)
+- Frontmatter parsed on open — populates `docTitle`, `docAuthors` in the document store
+- Recent files tracked in `~/.quire/recent.json` (max 15, Unix-seconds timestamps)
+
+### Hamburger menu
+- `≡` button in the TitleBar opens a slide-in panel
+- New Document, Open File, and a Recent Files list with relative timestamps (`2h ago` etc.)
+- Outside-click and Escape to dismiss
+
+### Navigation views (placeholder data, real UI)
+- **Workbench** (`/workbench`) — annotation blocks with coloured source tags, draft outline
+- **PDF** (`/pdf`) — simulated split: PDF page left, citing-drafts + annotations right
+
+### Quarto export
+- "Export as PDF" button invokes `quarto render` via `tauri-plugin-shell`
+- Requires Quarto CLI in PATH; wired up but not tested end-to-end
+
+---
+
+## Architecture decisions and why they were made
+
+### Module-level reactive singletons instead of Pinia
+`useDocument()` returns module-level `ref()`s that are shared across all component instances. Avoids the Pinia boilerplate for a project this size. The composable is a thin wrapper around the refs — every caller gets the same underlying reactive objects. Do not refactor this to Pinia without a clear reason; the current approach is intentional.
+
+### mitt event bus for editor ↔ component communication
+Tiptap NodeViews are isolated from the parent component's template scope. There is no clean Vue way to bind events from inside a ProseMirror NodeView to the parent. The pattern is: NodeView fires `emitter.emit('cite:hover', ...)`, `WriteView.vue` listens in `onMounted`. This is correct and intentional — do not try to replace it with props/emits.
+
+Key events:
+- `cite:hover { key, rect }` — fired on citation mouseenter
+- `cite:leave` — fired on citation mouseleave
+- `cite:click { key }` — fired on citation click
+- `doc:opened { path, content }` — fired when a file loads (editor resets content)
+- `doc:saved { path }` — fired on successful save
+- `export:start / export:done / export:error` — for the status bar
+
+### Hash history router
+`createWebHashHistory()` is used because Tauri serves from a file URL, not a real origin. `createWebHistory()` breaks in production Tauri builds. Do not change this.
+
+### Rust `.bib` parser (no crates)
+The parser in `src-tauri/src/lib.rs` handles `.bib` correctly without `biblatex` or `nom` crates. It splits on `@`, reads depth-tracked braces/quotes for values, handles nested braces in abstracts. It was written by hand because adding a `.bib` parsing crate to the Tauri binary caused build complexity that wasn't worth it at M0. The parser is not perfect (it does not handle all edge cases) but it handles the common journal article entry format used by Zotero exports.
+
+### `.qmd` as document format
+Quarto Markdown is the document format. It's plain Markdown with YAML frontmatter, and Quarto can render it to PDF, DOCX, HTML. The editor saves HTML from Tiptap and the Rust backend writes it as `.qmd`. This is a simplification — real `.qmd` stores Markdown, not HTML — and will need revisiting in M1 when the export pipeline needs to produce correct Quarto output.
+
+### Mac aesthetic with plain CSS
+No Tailwind, no component library, no CSS framework. All styles are in `src/assets/style.css` (global tokens) and `src/assets/editor.css` (Tiptap-specific). This is intentional — the app targets macOS aesthetic precisely, and framework utilities would fight the fine-grained control the design requires.
+
+Key design tokens in `style.css`:
+- `--bg: #F5F4F1` — warm off-white, document background
+- `--bg-chrome: #EDECEA` — slightly cooler, used for titlebar/sidebar
+- `--bg-document: #E8E6E0` — the document canvas behind the paper card
+- `--surface-solid: #FFFFFF` — the paper card itself
+- `--accent: #0A5FBF` — citation blue, primary interactive colour
+- `--accent-orange: #E8650A` — unresolved citation `[?]`
+- `--font-doc: Georgia, "Times New Roman", serif` — body text in editor
+- `--font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", sans-serif`
+
+---
+
+## Key files map
+
+```
+src/
+├── assets/
+│   ├── style.css              ← Global CSS variables. Change tokens here to retheme.
+│   └── editor.css             ← ProseMirror/Tiptap styles. .cite-sup-node lives here.
+├── events.ts                  ← mitt event bus. All event types are typed here.
+├── composables/
+│   ├── useDocument.ts         ← THE reactive store. Module-level singletons. Read this first.
+│   ├── useFileOps.ts          ← open/save/saveAs/tryLoadBib. Bridges Tauri commands ↔ store.
+│   └── useQuire.ts            ← initQuire (loads global .bib), recent files, relativeTime.
+├── extensions/
+│   ├── CitationNode.ts        ← Tiptap node definition. Attributes: citeKey, displayIndex.
+│   └── CitationSuggest.ts     ← @ autocomplete extension. Uses @tiptap/suggestion.
+├── components/
+│   ├── CitationNodeView.vue   ← Renders each [N] in the editor. Fires cite:* events.
+│   ├── CitationSuggestList.vue ← The @ dropdown popup. Exposes onKeyDown to extension.
+│   ├── HamburgerMenu.vue      ← ≡ menu: new doc, open file, recent files.
+│   ├── TitleBar.vue           ← Traffic lights + title + export button + ≡ trigger.
+│   ├── Sidebar.vue            ← 52px icon strip, 3 route links.
+│   └── StatusBar.vue          ← Word count, save status, dirty indicator.
+├── views/
+│   ├── WriteView.vue          ← The editor. Most complex file. Tiptap + panels + events.
+│   ├── WorkbenchView.vue      ← Placeholder. Real implementation is M1.
+│   └── PdfView.vue            ← Placeholder. Real implementation is M2.
+└── App.vue                    ← Shell: titlebar, sidebar, statusbar, hamburger, router-view.
+
+src-tauri/src/lib.rs           ← All Rust commands. .bib parser, .qmd read/write, recent files.
+~/.quire/references.bib        ← The global bibliography. Single source of truth.
+~/.quire/recent.json           ← Recent files list. [ { path, title, last_opened } ]
+```
+
+---
+
+## What's next (M1 priorities, in order)
+
+1. **Fix the .qmd save format** — currently saves Tiptap's HTML output, which isn't valid `.qmd`. The save pipeline needs to convert Tiptap's HTML to Markdown (using Tiptap's `generateText` or a ProseMirror serialiser), wrap in YAML frontmatter, and write that. The editor should load `.qmd` by parsing the Markdown back to Tiptap HTML on open.
+
+2. **Zotero annotation import** — Zotero stores PDF annotations in `~/Zotero/zotero.sqlite`. Read highlighted text + page number + source paper per highlight, surface them as workbench blocks. No API required — just SQLite reads.
+
+3. **Real Workbench** — replace the placeholder `WorkbenchView.vue` with actual annotation blocks sourced from (2). Drag-to-draft: dragging a block into the editor inserts a blockquote with the cite-key attached.
+
+4. **Quarto export test** — verify the `run_quarto` Rust command actually works end-to-end with a real `.qmd` file. The command exists; it has not been tested against a real document.
+
+5. **Auto-save** — save every 60s if dirty, not just on Ctrl+S.
+
+---
+
+## What to never do
+
+- **Don't add Pinia.** The singleton composable pattern is intentional.
+- **Don't change hash history to web history.** Production Tauri builds break.
+- **Don't add a CSS framework.** The design requires precise control; utilities fight it.
+- **Don't store document content in the Rust backend state.** The frontend owns document state; Rust just reads and writes files on demand.
+- **Don't add Zotero API integration.** The design decision is file-watching the local Zotero SQLite and Better BibTeX exports — no auth, no sync, no API key.
+- **Don't touch WorkbenchView or PdfView until M1/M2.** They are correct placeholders; premature implementation before the data layer exists would produce throwaway code.
+
+---
+
+## The user
+
+The user is a researcher/developer at IIT Madras working on food policy and allergen labelling. They have prior experience with Tauri and are comfortable with Rust, Vue, and TypeScript at an intermediate level. They care deeply about the UX details — the "Mac aesthetic" is not a preference, it is a constraint. When in doubt, match macOS system UI: native blur, muted borders, traffic-light window controls, Georgia serif for document body, system-ui for chrome.
+
+The project is personal and research-motivated. Decisions should be made to serve the actual allergen paper session workflow, not to build a general-purpose tool.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,17 +158,53 @@ src-tauri/src/lib.rs           ← All Rust commands. .bib parser, .qmd read/wri
 
 ---
 
+## Known gaps and honest state (assessed after M0)
+
+This section captures an honest audit of what M0 actually delivers versus what it promises. Read before starting M1 work.
+
+### Critical: the .qmd save format is broken
+`useFileOps.ts` saves Tiptap's raw HTML output as the document body. A file saved by Quire is not valid Quarto Markdown — Quarto cannot render it, and it's unreadable in any other editor. **This is the first thing to fix in M1, before anything else.** The fix: add a ProseMirror HTML→Markdown serialiser on save, and a Markdown→Tiptap HTML parser on load. Tiptap's `@tiptap/pm` gives access to the ProseMirror model; a custom serialiser is ~100 lines. The citation node needs a special serialisation rule: `[@citeKey]` in Pandoc citation syntax.
+
+### Citation numbering is static and will become friction
+`displayIndex` is assigned at insertion time and never updated. If a user inserts a citation at the top of the document after already having `[1]`, `[2]`, `[3]` lower down, the numbers don't reorder. For M0 this is tolerable; in real use it becomes a constant annoyance. Fix: on every editor update, traverse the document, collect citation nodes in order, reassign indices by unique key in order of first appearance, update node attrs. This is a ProseMirror transaction-based operation.
+
+### The workbench — the most novel feature — is entirely placeholder
+The workbench is the genuinely differentiated idea: annotation blocks from multiple source PDFs, spatially organised against a draft outline, drag-to-insert into prose. No tool in the researcher's current stack does this. But `WorkbenchView.vue` is 100% hardcoded fake data. Until Zotero's SQLite is being read (M1), Quire's most important feature does not exist. The UI shell is correct; the data layer is missing entirely.
+
+### Quarto export is wired but untested end-to-end
+`run_quarto` exists in `lib.rs` and the export button is wired. It has never been run against a real document. It will also produce garbage output until the .qmd save format is fixed.
+
+### Citation panel is read-only
+You cannot add, edit, or delete `.bib` entries from within Quire. Adding a new reference requires editing `~/.quire/references.bib` externally and relaunching (or triggering a re-load). A minimal in-app "Add entry" form would close this gap; a full editor is probably overkill for M1.
+
+### Missing basic academic editor features
+Tables, figure captions, math/equations (critical for STEM fields), footnotes, and cross-references are all absent. These are Tiptap extensions and are addable incrementally; they are not architectural problems. Prioritise based on the allergen paper's actual content — it used tables and statistics.
+
+### What genuinely works right now
+- `@` autocomplete is immediately useful
+- Citation hover/click panel is better than the Zotero equivalent for in-flow reference checking
+- Global `.bib` design is sound
+- `[?]` unresolved indicator is a good editorial guardrail
+- The file open/save/recent files loop works correctly (modulo the HTML format issue)
+- The aesthetic and shell are production-quality
+
+---
+
 ## What's next (M1 priorities, in order)
 
-1. **Fix the .qmd save format** — currently saves Tiptap's HTML output, which isn't valid `.qmd`. The save pipeline needs to convert Tiptap's HTML to Markdown (using Tiptap's `generateText` or a ProseMirror serialiser), wrap in YAML frontmatter, and write that. The editor should load `.qmd` by parsing the Markdown back to Tiptap HTML on open.
+1. **Fix the .qmd save format** — blocker for everything else. Write a ProseMirror→Markdown serialiser that handles paragraphs, headings, and citation nodes (serialise as `[@citeKey]` in Pandoc syntax). On load, parse Markdown back to Tiptap HTML. See "Known gaps" section above for detail.
 
-2. **Zotero annotation import** — Zotero stores PDF annotations in `~/Zotero/zotero.sqlite`. Read highlighted text + page number + source paper per highlight, surface them as workbench blocks. No API required — just SQLite reads.
+2. **Dynamic citation index recomputation** — on every editor transaction, traverse document, collect citations in order of appearance, reassign `displayIndex` by unique key. Prevents numbering drift as the user writes.
 
-3. **Real Workbench** — replace the placeholder `WorkbenchView.vue` with actual annotation blocks sourced from (2). Drag-to-draft: dragging a block into the editor inserts a blockquote with the cite-key attached.
+3. **Quarto export end-to-end test** — once the save format is fixed, run `run_quarto` against a real `.qmd` and verify the PDF output is correct. Fix any issues in the Rust command.
 
-4. **Quarto export test** — verify the `run_quarto` Rust command actually works end-to-end with a real `.qmd` file. The command exists; it has not been tested against a real document.
+4. **Zotero annotation import** — read `~/Zotero/zotero.sqlite` (no API, no auth). Extract: highlighted text, page number, colour, source paper (match to `.bib` key). Surface as workbench blocks.
 
-5. **Auto-save** — save every 60s if dirty, not just on Ctrl+S.
+5. **Real Workbench** — replace placeholder `WorkbenchView.vue` with annotation blocks from (4). Drag-to-draft inserts a blockquote with the cite-key attached.
+
+6. **Auto-save** — save every 60s if dirty.
+
+7. **Minimal in-app bib entry form** — a simple "Add reference" sheet (title, authors, year, key, journal, DOI) that appends to `~/.quire/references.bib`. Removes the need to edit the file externally.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,94 @@
-# Tauri + Vue + TypeScript
+# Quire — Integrated Research Environment
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+A desktop writing environment for researchers who work with citations, annotations, and source-heavy prose. Built with Tauri 2, Vue 3, and TypeScript.
 
-## Recommended IDE Setup
+---
 
-- [VS Code](https://code.visualstudio.com/) + [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+## The problem it solves
+
+Writing a cited paragraph currently means switching between your editor, a PDF reader, a reference manager, and a notes app — often several times per sentence. Quire keeps citations, source annotations, and prose in one place, so you can write and verify in the same window.
+
+## M0 feature set (current)
+
+- **WYSIWYG `.qmd` editor** — ProseMirror via Tiptap, Georgia body type, section headings rendered inline
+- **Inline citations** — `[1]` `[2]` superscripts backed by real `.bib` keys; hover for a quick card, click to open a full side panel
+- **Unresolved citation indicator** — any `citeKey` with no matching entry in the `.bib` renders as orange `[?]` with a tooltip naming the missing key
+- **Global bibliography** — `~/.quire/references.bib` is the single source of truth across all projects; seeded with sample entries on first run
+- **Hamburger menu** — `≡` in the title bar opens a quick-access panel with New Document, Open File, and a Recent Files list with relative timestamps
+- **Open / Save / Save As** — native file dialogs via `tauri-plugin-dialog`; documents saved as `.qmd` with YAML frontmatter
+- **Quarto export** — "Export as PDF" invokes `quarto render` via `tauri-plugin-shell`; requires Quarto CLI in PATH
+- **Workbench view** — annotation blocks from multiple sources with colour-coded source tags (placeholder data, M1 wires real Zotero annotations)
+- **PDF viewer** — split layout: simulated PDF page on the left, citing-drafts + annotation cards on the right (placeholder, M2 wires real PDF.js)
+
+## Tech stack
+
+| Layer | Library |
+|---|---|
+| Desktop shell | Tauri 2 |
+| Frontend framework | Vue 3 + TypeScript (Vite 6) |
+| Editor | Tiptap v2 (ProseMirror) |
+| Routing | vue-router 4 |
+| Events | mitt |
+| File dialogs | tauri-plugin-dialog |
+| Shell execution | tauri-plugin-shell |
+| Home dir (Rust) | dirs 5 |
+
+## Getting started
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) (stable)
+- [Node.js](https://nodejs.org/) ≥ 18
+- [Tauri CLI v2](https://tauri.app/start/prerequisites/)
+- [Quarto CLI](https://quarto.org/docs/get-started/) (optional — only needed for PDF export)
+
+### Development
+
+```bash
+npm install
+npm run tauri dev
+```
+
+The app opens at its own window (not a browser tab). Hot-reload is active for the Vue frontend; Rust changes require a recompile.
+
+### Production build
+
+```bash
+npm run tauri build
+```
+
+Outputs a native installer in `src-tauri/target/release/bundle/`.
+
+## Project layout
+
+```
+quire/
+├── src/                      # Vue frontend
+│   ├── assets/               # Global CSS (style.css, editor.css)
+│   ├── components/           # TitleBar, Sidebar, StatusBar, HamburgerMenu,
+│   │                         # CitationNodeView, CitationTooltip, CitationPanel
+│   ├── composables/          # useDocument, useFileOps, useQuire
+│   ├── events.ts             # mitt event bus (cite:*, doc:*, export:*)
+│   ├── extensions/           # CitationNode Tiptap extension
+│   ├── router/               # vue-router routes
+│   └── views/                # WriteView, WorkbenchView, PdfView
+└── src-tauri/                # Rust backend
+    └── src/lib.rs            # Tauri commands: open/save, .bib parsing, recent files
+```
+
+## Data storage
+
+On first launch Quire creates `~/.quire/` containing:
+
+- `references.bib` — global bibliography, pre-seeded with four sample entries
+- `recent.json` — list of recently opened files (max 15, managed automatically)
+
+Every project reads from `~/.quire/references.bib` by default. A local `.bib` file in the same directory as a `.qmd` document will take precedence if present.
+
+## Roadmap
+
+See [`ROADMAP.md`](ROADMAP.md) for the full milestone breakdown (M0–M6).
+
+## Development setup
+
+- VS Code + [Vue - Official](https://marketplace.visualstudio.com/items?itemName=Vue.volar) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Writing a cited paragraph currently means switching between your editor, a PDF r
 
 - **WYSIWYG `.qmd` editor** — ProseMirror via Tiptap, Georgia body type, section headings rendered inline
 - **Inline citations** — `[1]` `[2]` superscripts backed by real `.bib` keys; hover for a quick card, click to open a full side panel
+- **`@` citation autocomplete** — type `@` anywhere in the editor to get an Overleaf-style dropdown of your bibliography; filter by key, title, or author with ↑↓ to navigate and Enter/click to insert
 - **Unresolved citation indicator** — any `citeKey` with no matching entry in the `.bib` renders as orange `[?]` with a tooltip naming the missing key
 - **Global bibliography** — `~/.quire/references.bib` is the single source of truth across all projects; seeded with sample entries on first run
 - **Hamburger menu** — `≡` in the title bar opens a quick-access panel with New Document, Open File, and a Recent Files list with relative timestamps
@@ -32,6 +33,7 @@ Writing a cited paragraph currently means switching between your editor, a PDF r
 | File dialogs | tauri-plugin-dialog |
 | Shell execution | tauri-plugin-shell |
 | Home dir (Rust) | dirs 5 |
+| Citation autocomplete | @tiptap/suggestion |
 
 ## Getting started
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,168 @@
+# Quire — Roadmap
+
+**Quire** is an Integrated Research Environment for narrative-first academic writing. Built on Tauri + Vue, it unifies the writing surface, literature references, annotation workbench, and document export into one coherent desktop app — replacing the fragmented stack of Zotero + Overleaf + Positron + Git + PDF viewer that researchers currently glue together by hand.
+
+> _A quire: a set of leaves folded together, forming the unit of a book._
+
+---
+
+## What exists now
+
+The frontend shell with placeholder data demonstrating all 5 core interaction states:
+
+- **Write view** — WYSIWYG document surface with inline citation markers (`[1]`, `[2]`, `[3]`)
+- **Citation tooltip** — hover any citation to see title, authors, abstract excerpt
+- **Citation panel** — click to open full source detail with your notes, side-by-side with the document
+- **Workbench** — annotation blocks pulled from sources, organised against the draft outline
+- **PDF reader** — split view: document page left, citing drafts + annotations right
+
+No real files. No real citations. No backend. Pure UI proof-of-concept.
+
+---
+
+## Milestone 0 — Minimal Viable First (now → working tool)
+
+> **Goal:** make the allergen paper session possible without leaving Quire once.
+
+The one session that motivated this project involved: version mismatch → tool switch → copy-pasting frontmatter → recovering data from git history → ctrl+F across 7 PDFs to trace 3 citation numbers → Google for an ORCID. Milestone 0 eliminates every one of those switches.
+
+### What to build
+
+**Rust backend (src-tauri/)**
+- `open_document(path)` → read `.qmd` file, return content
+- `save_document(path, content)` → write `.qmd`
+- `load_bib(path)` → parse `.bib`, return structured list of entries
+- `run_quarto(path, format)` → shell out to `quarto render`, stream stdout back
+
+**Frontend wiring**
+- Replace placeholder prose with a real editor — integrate **Tiptap** (ProseMirror-based, Vue-native, supports custom nodes)
+- Add a custom Tiptap citation node: renders as `[1]` superscript, stores the cite-key internally
+- On app open: file picker → load `.qmd` + auto-detect `.bib` in same directory
+- Citation panel: reads from the loaded `.bib` — real titles, authors, abstracts
+- Export button: calls `run_quarto`, shows a progress toast, opens the output file
+
+**File handling**
+- Parse YAML frontmatter from `.qmd` on load (title, authors, date → TitleBar)
+- Save on `Ctrl+S`, auto-save every 60s
+- Show unsaved indicator in TitleBar ("●" before title)
+
+### What this unlocks
+
+A researcher can open their real `.qmd` manuscript, see their actual `.bib` citations resolve in the hover panel, and export to PDF — all without leaving Quire. The core citation-tracing pain from the allergen session is gone.
+
+### Estimated scope
+~4–6 sessions of focused work. Tiptap integration is the largest single piece.
+
+---
+
+## Milestone 1 — Workbench as a real tool
+
+> **Goal:** annotation blocks pulled from actual sources, not typed by hand.
+
+- **Zotero connector**: read from Zotero's local Better BibTeX JSON export (`~/Zotero/...`) — no API key, no sync, just file watching
+- **PDF annotation import**: Zotero stores PDF annotations in its SQLite database — read highlighted text + page number + color per paper, surface them as workbench blocks automatically
+- **Drag to draft**: drag an annotation block from the workbench into the document — inserts a blockquote with the cite-key attached
+- **Block provenance**: every block remembers its source paper + page; clicking it opens PDF reader at that exact page
+- **Workbench persistence**: save workbench state per document in a sidecar `.quire.json` file
+
+---
+
+## Milestone 2 — PDF reader with real rendering
+
+> **Goal:** replace the placeholder PDF page with an actual rendered document.
+
+- Integrate **PDF.js** (via npm) in the PDF view — render real pages
+- Highlight annotations synced from Zotero data
+- Click a highlighted region → jump to that annotation block in the Workbench
+- "Back" navigation: click citation `[1]` in your draft → open that source's PDF at the relevant page → back arrow returns to draft cursor position
+- Search within PDF (replaces the ctrl+F workflow)
+
+---
+
+## Milestone 3 — Author registry
+
+> **Goal:** author metadata as a first-class object, not a Google search.
+
+- **Author panel**: a lab-level author registry (stored in `~/.quire/authors.json`)
+- Fields: display name, ORCID, affiliation, email, CRediT roles
+- On document open: parse `authors:` frontmatter → match to registry or prompt to add
+- ORCID lookup: type a name → fetch from `https://pub.orcid.org/v3.0/search` → one-click import
+- CRediT roles picker: checkboxes for all 14 CRediT taxonomy roles, written into frontmatter
+- Used by the export pipeline: auto-formats author block for different journal templates
+
+---
+
+## Milestone 4 — Git-aware document history
+
+> **Goal:** version control that understands research stages, not just diffs.
+
+- **Stage labels**: on commit, tag with a research stage — `drafting`, `revising`, `under-review`, `submitted`, `published`
+- **History panel**: a fourth sidebar mode showing commit history with stage labels and word count delta
+- **Prose diff**: side-by-side diff view using sentence-level diffing (not line-level — prose doesn't live in lines)
+- **Recover from history**: the allergen session had to manually copy data from a GitHub commit — Quire shows history inline and lets you copy any paragraph from any past version
+- Wraps `git` via Tauri shell commands — no separate git installation required beyond what Tauri already bundles
+
+---
+
+## Milestone 5 — Multi-format export pipeline
+
+> **Goal:** replace Overleaf as the compilation environment.
+
+- Export targets: PDF (via Quarto + LaTeX), DOCX, HTML, ePub
+- **Journal templates**: download and apply Quarto journal templates (ASA, APA, Nature, PLOS, etc.) from a curated list
+- **Preflight check**: before export, verify — all citations resolve in .bib, all figures have captions, word count within target, required frontmatter fields present
+- **LaTeX passthrough**: for journals that require raw `.tex` — Quire generates the `.tex` and lets you inspect/edit before bundling
+- Export history: every export is logged with timestamp + format + git commit SHA → full audit trail from draft to submission
+
+---
+
+## Milestone 6 — Collaboration (stretch)
+
+> **Goal:** co-authoring without leaving Quire.
+
+- Comment threads on any paragraph (stored in `.quire.json`, not in the document itself)
+- Annotated docx import: parse revision marks from a supervisor's `.docx` → surface them as inline comments in the writing view (this directly replaces the "opened annotated docx in Google Forms" step from the allergen session)
+- Export author contributions section from the CRediT registry automatically
+- SMTP integration: send draft for review directly from Quire, with ORCID-formatted author metadata pre-filled
+
+---
+
+## Dependency order
+
+```
+Milestone 0 (real editing + real .bib)
+    └── Milestone 1 (workbench with real annotations)
+            └── Milestone 2 (PDF reader — needs annotation data from M1)
+Milestone 0
+    └── Milestone 3 (author registry — needs frontmatter parsing from M0)
+            └── Milestone 5 (export pipeline — needs author registry for templates)
+Milestone 0
+    └── Milestone 4 (git history — needs real files to track)
+Milestones 1–5
+    └── Milestone 6 (collaboration — builds on all prior layers)
+```
+
+---
+
+## Non-goals (explicitly out of scope)
+
+- **Real-time collaborative editing** (Google Docs model) — out of scope; this is a local-first tool
+- **Cloud sync** — Quire works on local files; sync is the user's responsibility (git, Dropbox, etc.)
+- **Reference discovery / lit search** — Quire manages sources you've already found, not finding them
+- **Data analysis / R/Python integration** — out of scope for v1; Quarto's execution model handles this if needed
+- **Mobile** — desktop only; Tauri mobile exists but research writing is a desktop workflow
+
+---
+
+## Stack decisions (locked)
+
+| Layer | Choice | Reason |
+|---|---|---|
+| Shell | Tauri 2 | Native desktop, small binary, Rust backend |
+| Frontend framework | Vue 3 + TypeScript | Existing setup, Composition API suits reactive panels |
+| Editor engine | Tiptap (Milestone 0) | ProseMirror-based, Vue-native, supports custom nodes |
+| PDF rendering | PDF.js (Milestone 2) | Browser-native, no native dependency |
+| Styling | Plain CSS + CSS variables | No framework overhead, full control |
+| Router | vue-router 4 | Already installed |
+| Citations | .bib parsing in Rust | Fast, no JS dependency for parsing |
+| Quarto/Pandoc | Shell via Tauri | Let Quarto handle the complexity |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/suggestion": "^3.22.4",
         "@tiptap/vue-3": "^3.22.4",
         "mitt": "^3.0.1",
+        "pdfjs-dist": "^5.6.205",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4"
       },
@@ -544,6 +545,271 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
+      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-arm64": "0.1.99",
+        "@napi-rs/canvas-darwin-x64": "0.1.99",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
+      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
+      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
+      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
+      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
+      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
+      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
+      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
+      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
+      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
+      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
+      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -2014,6 +2280,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
@@ -2026,6 +2299,19 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tiptap/pm": "^3.22.4",
+        "@tiptap/starter-kit": "^3.22.4",
+        "@tiptap/vue-3": "^3.22.4",
+        "mitt": "^3.0.1",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4"
       },
@@ -508,6 +512,31 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -1155,6 +1184,427 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.4.tgz",
+      "integrity": "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.4.tgz",
+      "integrity": "sha512-jIaPKfNOQu2lhpbLDvtwlQqM+mjF+Kk+auHpzYjBnsuwUli1Cl5ZOau7RH+rru/SQvZe1DtpQlANujDywugZAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
+      "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.4.tgz",
+      "integrity": "sha512-TB+d3fGcTixYjO7coKqTr1mGTJuqr8hjDCPUFgzuvKyJnBhqWITmBzQ/8CLq4rr6mihgGURbD3N+xkQuPAKFiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.4.tgz",
+      "integrity": "sha512-cnbxmVhAcc7X3G81QUYEmKP0ve2hRmvAiFXBuuv9RUtQlBiRnzmhHoJOMgkX0CsMR7+8kMRpTfeDUYq2xp5s5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.4.tgz",
+      "integrity": "sha512-MEurzNXfMET3rhjpoPJYUgMfxTdTqbzT9+ToFrqNGAHocdXVm6m1hhO2frVC7fEtHPnxXKsn0Z3NUbCRkRTLuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.4.tgz",
+      "integrity": "sha512-XQKla1+703FqQJC48tPDVgt9ucGiFbIEmQdOg5L5o07z9a6/NzuaZAc+1zJ7NxcUZzy+z6wBn1PrVMTiqiSXlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.4.tgz",
+      "integrity": "sha512-N9/yMDC35jJp0V/naL0+6gi4gUDUIcPpWEzFdCDWUSYBA8mt41c1kI1ZU7UTKYIBzTClenhYHRc2XKZxxx0+LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
+      "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.4.tgz",
+      "integrity": "sha512-UYBEUj3SFpKINIE7AdzcyeS3xICK+ee+YLBbuqNXyHStYChjJOohzJehqiqhjR16A88KQQ+ZjgyDcItKGygSog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.4.tgz",
+      "integrity": "sha512-xq+a4dE7T6VwApCkh/yU3p30gn3F8g8Arb9CyEZm58/WIJUIGvHSTjDdHmvU16+kiWSBg+wOOsaFHhYjJjxcKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.4.tgz",
+      "integrity": "sha512-TUaj5f0Ir5qy9HKKt2ocnwfXKpZDYeHgbbP9gshKFzdq5PLe1RbIgkjfy6bnoI865cYjmPYWRjcT7XsKyIcb9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.4.tgz",
+      "integrity": "sha512-cCI1HekGQwhY/MbgaKQ0R/7HcH5ZM1oFAyI/J72QGLC0XnF403S/OXoHMuBWr1mCu8hNiQWCzeNRJUty0iytNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.4.tgz",
+      "integrity": "sha512-fVSDx5AYXgDI3v2zZIqb7V8EewthwM2NJ/ZCX+XaxRsqNEpnjVhgHs7UlvDqK1wj2OJ6zmUNjPtVlAFRxwT+HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
+      "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
+      "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.4.tgz",
+      "integrity": "sha512-H659KXTvggSypIDWSOJBZ37jh9pKjQriDDvYPYvOZCdfij0D0hsDXN/wXoypArneUkoBdgruHfTtMkFOaQlgkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.4.tgz",
+      "integrity": "sha512-t/zhker4oIS78AIGYDdFFfZC6zSBlszfD7z/zqFLGCg5PHNNgkZK5hKj6Vyix6D2SapRn/ajnx+8mhbKIUH5eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
+      "integrity": "sha512-w77hPVf7pcHt97vfrybg/l0t5CimCd4y75OJKuHuo3CfgM5xbUP/gaPNMDyLLe7MYole/UHi/XvG3XjgzqTzAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.4.tgz",
+      "integrity": "sha512-de6dFkIhigiENESY6rNJ3yTVS/337ybfP30dNPudTwGe9oAu9ZCS+04j6QCvXSjhlI3ULiv7wiSHqrP26Gd+Hw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.4.tgz",
+      "integrity": "sha512-aRHWQj42HiailXSC9LkKYM3jWMcSeGwOjbqM4PiuxQZmHVDRFmeHkfJItOdn2cSHaO0vuEVK+TvrWUWsBFi3pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.4.tgz",
+      "integrity": "sha512-mM69uUW5cSxIhyEpWXi/YcfyupcJMDLCPEfYi62awH0iOP/LRoCv/nHjJq4Hyj/KxRJbe8HKwIUnqaCUf7m5Pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.4.tgz",
+      "integrity": "sha512-08kGdbhIrA6h10GWXqOkqIveaBj5tmxclK208/nUIAlonI9hPd739vu7fmVtpnmqCnSSNpoRtU4u6Gj5at0ZpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
+      "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.4.tgz",
+      "integrity": "sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/extension-blockquote": "^3.22.4",
+        "@tiptap/extension-bold": "^3.22.4",
+        "@tiptap/extension-bullet-list": "^3.22.4",
+        "@tiptap/extension-code": "^3.22.4",
+        "@tiptap/extension-code-block": "^3.22.4",
+        "@tiptap/extension-document": "^3.22.4",
+        "@tiptap/extension-dropcursor": "^3.22.4",
+        "@tiptap/extension-gapcursor": "^3.22.4",
+        "@tiptap/extension-hard-break": "^3.22.4",
+        "@tiptap/extension-heading": "^3.22.4",
+        "@tiptap/extension-horizontal-rule": "^3.22.4",
+        "@tiptap/extension-italic": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
+        "@tiptap/extension-list": "^3.22.4",
+        "@tiptap/extension-list-item": "^3.22.4",
+        "@tiptap/extension-list-keymap": "^3.22.4",
+        "@tiptap/extension-ordered-list": "^3.22.4",
+        "@tiptap/extension-paragraph": "^3.22.4",
+        "@tiptap/extension-strike": "^3.22.4",
+        "@tiptap/extension-text": "^3.22.4",
+        "@tiptap/extension-underline": "^3.22.4",
+        "@tiptap/extensions": "^3.22.4",
+        "@tiptap/pm": "^3.22.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/vue-3": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.22.4.tgz",
+      "integrity": "sha512-fcqUWt6LlA5PbcFaDXyV1apWwAs8j80m0kWwoL5+DgKdkGxsB5LgDZU1pTWle0zvR5zmGvJ7LmB6EGAYIBjdmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.4",
+        "@tiptap/extension-floating-menu": "^3.22.4"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1487,6 +1937,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1512,6 +1968,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
@@ -1536,6 +1998,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -1591,6 +2059,135 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -1635,6 +2232,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1810,6 +2413,12 @@
       "peerDependencies": {
         "typescript": ">=5.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tauri-apps/plugin-opener": "^2",
         "@tiptap/pm": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
+        "@tiptap/suggestion": "^3.22.4",
         "@tiptap/vue-3": "^3.22.4",
         "mitt": "^3.0.1",
         "vue": "^3.5.13",
@@ -1583,6 +1584,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.22.4.tgz",
+      "integrity": "sha512-1buvLZemITTeKmPf2wGFWvvhRFKjdQ+JgMqc67xBraOKeDd8wQi1e2XlhCYAtlVMm5f6j+qlLC/MvwuHI2jHeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
       }
     },
     "node_modules/@tiptap/vue-3": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tiptap/extension-mathematics": "^3.22.4",
         "@tiptap/pm": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
         "@tiptap/suggestion": "^3.22.4",
         "@tiptap/vue-3": "^3.22.4",
+        "katex": "^0.16.45",
         "mitt": "^3.0.1",
         "pdfjs-dist": "^5.6.205",
         "vue": "^3.5.13",
@@ -1713,6 +1715,21 @@
         "@tiptap/extension-list": "3.22.4"
       }
     },
+    "node_modules/@tiptap/extension-mathematics": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mathematics/-/extension-mathematics-3.22.4.tgz",
+      "integrity": "sha512-I5v+Aj+afoes8/1PhMy0Xp1d4ibnOE5COBmjsJTxpbPn4CdzJpnSBGKoIhBzbc8FDsPuVd/vCPvxsCDzEssTIA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "katex": "^0.16.4"
+      }
+    },
     "node_modules/@tiptap/extension-ordered-list": {
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
@@ -2102,6 +2119,15 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2216,6 +2242,22 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/linkifyjs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tiptap/suggestion": "^3.22.4",
     "@tiptap/vue-3": "^3.22.4",
     "mitt": "^3.0.1",
+    "pdfjs-dist": "^5.6.205",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tiptap/pm": "^3.22.4",
+    "@tiptap/starter-kit": "^3.22.4",
+    "@tiptap/vue-3": "^3.22.4",
+    "mitt": "^3.0.1",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tiptap/extension-mathematics": "^3.22.4",
     "@tiptap/pm": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@tiptap/suggestion": "^3.22.4",
     "@tiptap/vue-3": "^3.22.4",
+    "katex": "^0.16.45",
     "mitt": "^3.0.1",
     "pdfjs-dist": "^5.6.205",
     "vue": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tiptap/pm": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
+    "@tiptap/suggestion": "^3.22.4",
     "@tiptap/vue-3": "^3.22.4",
     "mitt": "^3.0.1",
     "vue": "^3.5.13",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -505,6 +505,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -526,9 +536,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -539,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1040,12 +1050,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1058,6 +1077,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1482,6 +1507,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1659,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1623,6 +1668,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1643,9 +1719,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1840,6 +1918,7 @@ name = "ire"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2214,6 +2293,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +2528,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3083,6 +3223,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3140,6 +3320,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,10 +3376,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3194,6 +3427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3252,6 +3494,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3393,6 +3658,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3676,6 +3953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +4012,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,7 +4053,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -3826,7 +4130,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4242,6 +4546,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,6 +4883,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -5050,6 +5380,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5101,6 +5442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5717,6 +6067,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -457,6 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,16 +511,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -536,9 +532,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -549,7 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -1050,21 +1046,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1077,12 +1064,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1329,8 +1310,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1340,9 +1323,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1507,25 +1492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,7 +1625,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1683,22 +1648,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1719,11 +1669,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1927,6 +1875,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]
@@ -2182,6 +2131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,23 +2245,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2528,50 +2466,6 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3034,6 +2928,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3029,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3229,29 +3207,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3259,6 +3234,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3382,6 +3358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3394,6 +3371,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3427,15 +3405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3494,29 +3463,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "selectors"
@@ -4012,27 +3958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,7 +3978,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -4532,6 +4457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,16 +4483,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -5139,6 +5069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5192,6 +5132,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5377,17 +5326,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,11 +726,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -729,7 +762,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -851,6 +884,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +966,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1435,6 +1489,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1447,6 +1510,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1767,11 +1839,15 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 name = "ire"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-shell",
 ]
 
 [[package]]
@@ -1986,6 +2062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2275,6 +2362,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2360,6 +2448,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2914,6 +3012,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3004,6 +3113,44 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3332,10 +3479,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3626,7 +3805,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3676,7 +3855,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3749,6 +3928,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,6 +3989,27 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4215,7 +4457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4366,6 +4608,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4848,6 +5096,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4886,6 +5143,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4947,6 +5219,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4965,6 +5243,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4980,6 +5264,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5013,6 +5303,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5028,6 +5324,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5049,6 +5351,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5064,6 +5372,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5224,7 +5538,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,4 +26,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 rusqlite = { version = "0.31", features = ["bundled"] }
+reqwest  = { version = "0.12", features = ["json"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,5 +26,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
 rusqlite = { version = "0.31", features = ["bundled"] }
-reqwest  = { version = "0.12", features = ["json"] }
+reqwest  = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio    = { version = "1", features = ["time"] }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,4 +24,5 @@ tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+dirs = "5"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
+rusqlite = { version = "0.31", features = ["bundled"] }
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
+    "shell:allow-execute",
+    "shell:allow-open"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,12 @@ pub use library::{
     import_bib_file, export_bib_file,
     // metadata fetch
     fetch_doi_metadata, fetch_arxiv_metadata, fetch_isbn_metadata,
+    // attachments
+    pick_and_attach_file, get_item_attachments, read_attachment_bytes,
+    open_attachment_external, remove_attachment,
+    // annotations
+    create_annotation, get_annotations_for_attachment,
+    delete_annotation, update_annotation_note,
 };
 
 use serde::{Deserialize, Serialize};
@@ -673,6 +679,17 @@ pub fn run() {
             fetch_doi_metadata,
             fetch_arxiv_metadata,
             fetch_isbn_metadata,
+            // Library — attachments
+            pick_and_attach_file,
+            get_item_attachments,
+            read_attachment_bytes,
+            open_attachment_external,
+            remove_attachment,
+            // Library — annotations
+            create_annotation,
+            get_annotations_for_attachment,
+            delete_annotation,
+            update_annotation_note,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,13 @@
 mod library;
 pub use library::{
+    // items
     create_library_item, delete_library_item, get_library_item, get_library_items,
     search_library_items, update_library_item,
+    // collections
+    add_item_to_collection, create_collection, delete_collection, get_collections,
+    get_item_collection_ids, remove_item_from_collection, rename_collection,
+    // tags
+    create_tag, delete_tag, get_tags, set_item_tags, update_tag_color,
 };
 
 use serde::{Deserialize, Serialize};
@@ -604,13 +610,27 @@ pub fn run() {
             load_bib,
             find_bib_for_document,
             run_quarto,
-            // Library (SQLite)
+            // Library — items
             get_library_items,
             get_library_item,
             create_library_item,
             update_library_item,
             delete_library_item,
             search_library_items,
+            // Library — collections
+            get_collections,
+            create_collection,
+            rename_collection,
+            delete_collection,
+            add_item_to_collection,
+            remove_item_from_collection,
+            get_item_collection_ids,
+            // Library — tags
+            get_tags,
+            create_tag,
+            update_tag_color,
+            delete_tag,
+            set_item_tags,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 // ── Data types ────────────────────────────────────────────────────────────────
@@ -34,12 +34,156 @@ pub struct FrontmatterFields {
     pub date: Option<String>,
 }
 
-// ── Commands ──────────────────────────────────────────────────────────────────
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RecentFile {
+    pub path: String,
+    pub title: String,
+    pub last_opened: String,
+}
+
+// ── Quire home directory ──────────────────────────────────────────────────────
+
+fn quire_home() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".quire")
+}
+
+fn global_bib_path() -> PathBuf {
+    quire_home().join("references.bib")
+}
+
+fn recent_json_path() -> PathBuf {
+    quire_home().join("recent.json")
+}
+
+const DEFAULT_BIB: &str = r#"% Quire global bibliography — ~/.quire/references.bib
+% Add your sources here. All Quire documents share this file.
+
+@article{popova2022,
+  title     = {Allergen Labelling Compliance in Food Manufacturing: A Systematic Review},
+  author    = {Popova, M. and Chen, L. and Okafor, R.},
+  year      = {2022},
+  journal   = {Food Control},
+  volume    = {134},
+  doi       = {10.1016/j.foodcont.2022.108940},
+  abstract  = {A systematic review examining allergen labelling compliance across 14 countries. Of 847 products sampled, 34% showed discrepancies between declared allergens and actual ingredient lists, with peanut and tree nut labelling showing the highest non-compliance rates. The study identifies inconsistent definition of precautionary labelling as a primary driver of consumer confusion.}
+}
+
+@techreport{fda2021,
+  title       = {Food Allergen Labeling and Consumer Protection Act: Compliance Report 2021},
+  author      = {{U.S. Food and Drug Administration}},
+  year        = {2021},
+  institution = {FDA},
+  number      = {FDA-TR-2021-0042},
+  abstract    = {Annual compliance report on FALCPA implementation, documenting a 1-in-8 consumer experience with allergic reactions attributable to labelling failures in packaged foods over a 24-month surveillance period. Survey conducted across n=12,400 households with at least one member reporting a food allergy.}
+}
+
+@article{hadley2019,
+  title    = {Hidden Allergens and Precautionary Labelling: Consumer Understanding and Risk},
+  author   = {Hadley, C. and King, J.},
+  year     = {2019},
+  journal  = {Journal of Allergy and Clinical Immunology},
+  volume   = {143},
+  number   = {3},
+  doi      = {10.1016/j.jaci.2018.11.025},
+  abstract = {Cross-sectional study of consumer comprehension of precautionary allergen labels (PAL) across a 2019 baseline cohort. Finds significant variation in PAL interpretation by education level and prior allergy diagnosis. 67% of respondents misinterpreted "may contain" as indicating lower risk than a direct ingredient declaration.}
+}
+
+@techreport{fssai2023,
+  title       = {Food Safety and Standards (Labelling and Display) Regulations 2020: Implementation Guidelines},
+  author      = {{Food Safety and Standards Authority of India}},
+  year        = {2023},
+  institution = {FSSAI},
+  abstract    = {Implementation guidelines for the 2020 labelling regulations, including threshold specifications for allergen declarations under Section 4.2.1 (10 mg/kg per individual allergen).}
+}
+"#;
+
+fn setup_quire_dir() {
+    let dir = quire_home();
+    if !dir.exists() {
+        fs::create_dir_all(&dir).ok();
+    }
+
+    let bib = global_bib_path();
+    if !bib.exists() {
+        fs::write(&bib, DEFAULT_BIB).ok();
+    }
+
+    let recent = recent_json_path();
+    if !recent.exists() {
+        fs::write(&recent, "[]").ok();
+    }
+}
+
+// ── Quire dir commands ────────────────────────────────────────────────────────
 
 #[tauri::command]
-async fn open_document(
-    app: tauri::AppHandle,
-) -> Result<OpenResult, String> {
+fn get_quire_dir() -> String {
+    quire_home().to_string_lossy().to_string()
+}
+
+#[tauri::command]
+fn get_global_bib() -> Result<Vec<BibEntry>, String> {
+    let content = fs::read_to_string(global_bib_path()).map_err(|e| e.to_string())?;
+    Ok(parse_bib(&content))
+}
+
+#[tauri::command]
+fn get_global_bib_raw() -> Result<String, String> {
+    fs::read_to_string(global_bib_path()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn save_global_bib(content: String) -> Result<(), String> {
+    fs::write(global_bib_path(), content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn get_recent_files() -> Result<Vec<RecentFile>, String> {
+    let content = fs::read_to_string(recent_json_path()).unwrap_or_else(|_| "[]".to_string());
+    serde_json::from_str(&content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn add_recent_file(path: String, title: String) -> Result<(), String> {
+    let content = fs::read_to_string(recent_json_path()).unwrap_or_else(|_| "[]".to_string());
+    let mut recent: Vec<RecentFile> = serde_json::from_str(&content).unwrap_or_default();
+
+    // Remove existing entry for this path, then prepend fresh entry
+    recent.retain(|r| r.path != path);
+    recent.insert(
+        0,
+        RecentFile {
+            path,
+            title,
+            last_opened: chrono_now(),
+        },
+    );
+
+    // Keep only the 15 most recent
+    recent.truncate(15);
+
+    let serialized = serde_json::to_string_pretty(&recent).map_err(|e| e.to_string())?;
+    fs::write(recent_json_path(), serialized).map_err(|e| e.to_string())
+}
+
+fn chrono_now() -> String {
+    // Simple ISO-8601 without pulling in chrono crate
+    // Uses SystemTime which is available in std
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as seconds since epoch — frontend converts to human label
+    secs.to_string()
+}
+
+// ── Document commands ─────────────────────────────────────────────────────────
+
+#[tauri::command]
+async fn open_document(app: tauri::AppHandle) -> Result<OpenResult, String> {
     use tauri_plugin_dialog::DialogExt;
 
     let path = app
@@ -60,10 +204,17 @@ async fn open_document(
 
     Ok(OpenResult {
         path: path_str,
-        content: content.clone(),
+        content,
         frontmatter,
         body,
     })
+}
+
+#[tauri::command]
+async fn open_document_path(path: String) -> Result<OpenResult, String> {
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let (frontmatter, body) = split_frontmatter(&content);
+    Ok(OpenResult { path, content, frontmatter, body })
 }
 
 #[tauri::command]
@@ -72,10 +223,7 @@ async fn save_document(path: String, content: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-async fn save_document_as(
-    app: tauri::AppHandle,
-    content: String,
-) -> Result<String, String> {
+async fn save_document_as(app: tauri::AppHandle, content: String) -> Result<String, String> {
     use tauri_plugin_dialog::DialogExt;
 
     let path = app
@@ -107,7 +255,6 @@ async fn find_bib_for_document(doc_path: String) -> Result<Option<String>, Strin
     let doc = Path::new(&doc_path);
     let dir = doc.parent().ok_or("Invalid path")?;
 
-    // Common .bib locations relative to the document
     let candidates = [
         doc.with_extension("bib"),
         dir.join("references.bib"),
@@ -121,15 +268,11 @@ async fn find_bib_for_document(doc_path: String) -> Result<Option<String>, Strin
         }
     }
 
-    // Walk up one directory level
     if let Some(parent) = dir.parent() {
-        let up_candidates = [
-            parent.join("references.bib"),
-            parent.join("bibliography.bib"),
-        ];
-        for candidate in &up_candidates {
-            if candidate.exists() {
-                return Ok(Some(candidate.to_string_lossy().to_string()));
+        for name in &["references.bib", "bibliography.bib"] {
+            let p = parent.join(name);
+            if p.exists() {
+                return Ok(Some(p.to_string_lossy().to_string()));
             }
         }
     }
@@ -145,20 +288,17 @@ async fn run_quarto(doc_path: String, format: String) -> Result<String, String> 
         .map_err(|e| format!("Failed to run quarto: {e}. Is Quarto installed and on PATH?"))?;
 
     if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        // Return the expected output path
-        let doc = Path::new(&doc_path);
         let ext = match format.as_str() {
             "pdf" => "pdf",
             "docx" => "docx",
             "html" => "html",
             _ => "pdf",
         };
-        let out_path = doc
+        let out_path = Path::new(&doc_path)
             .with_extension(ext)
             .to_string_lossy()
             .to_string();
-        Ok(format!("{}\nOutput: {}", stdout.trim(), out_path))
+        Ok(format!("Render complete\nOutput: {out_path}"))
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         Err(format!("Quarto error:\n{}", stderr.trim()))
@@ -171,22 +311,14 @@ fn split_frontmatter(content: &str) -> (FrontmatterFields, String) {
     if !content.starts_with("---") {
         return (FrontmatterFields::default(), content.to_string());
     }
-
-    // Find closing ---
     let after_open = &content[3..];
-    let close_pos = after_open.find("\n---")
-        .or_else(|| after_open.find("\r\n---"));
-
+    let close_pos = after_open.find("\n---").or_else(|| after_open.find("\r\n---"));
     let Some(pos) = close_pos else {
         return (FrontmatterFields::default(), content.to_string());
     };
-
     let yaml = &after_open[..pos];
-    let body_start = pos + 4; // skip "\n---"
-    let body = after_open[body_start..].trim_start().to_string();
-
-    let fields = parse_frontmatter_fields(yaml);
-    (fields, body)
+    let body = after_open[pos + 4..].trim_start().to_string();
+    (parse_frontmatter_fields(yaml), body)
 }
 
 fn parse_frontmatter_fields(yaml: &str) -> FrontmatterFields {
@@ -197,7 +329,6 @@ fn parse_frontmatter_fields(yaml: &str) -> FrontmatterFields {
 
     for line in yaml.lines() {
         let trimmed = line.trim();
-
         if let Some(rest) = trimmed.strip_prefix("title:") {
             title = Some(clean_yaml_string(rest.trim()));
             in_authors = false;
@@ -208,13 +339,15 @@ fn parse_frontmatter_fields(yaml: &str) -> FrontmatterFields {
             in_authors = false;
         } else if in_authors && trimmed.starts_with('-') {
             let author = trimmed.trim_start_matches('-').trim();
-            // Handle "- name: ..." vs "- Author Name"
-            if let Some(rest) = author.strip_prefix("name:") {
-                authors.push(clean_yaml_string(rest.trim()));
-            } else if !author.is_empty() {
-                authors.push(clean_yaml_string(author));
+            let name = if let Some(rest) = author.strip_prefix("name:") {
+                clean_yaml_string(rest.trim())
+            } else {
+                clean_yaml_string(author)
+            };
+            if !name.is_empty() {
+                authors.push(name);
             }
-        } else if !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
+        } else if !trimmed.starts_with(' ') && !trimmed.starts_with('-') && !trimmed.is_empty() {
             in_authors = false;
         }
     }
@@ -232,7 +365,6 @@ fn parse_bib(content: &str) -> Vec<BibEntry> {
     let mut entries = Vec::new();
     let chars: Vec<char> = content.chars().collect();
     let mut i = 0;
-
     while i < chars.len() {
         if chars[i] == '@' {
             i += 1;
@@ -243,12 +375,10 @@ fn parse_bib(content: &str) -> Vec<BibEntry> {
             i += 1;
         }
     }
-
     entries
 }
 
 fn parse_bib_entry(chars: &[char], i: &mut usize) -> Option<BibEntry> {
-    // Read entry type
     let type_start = *i;
     while *i < chars.len() && chars[*i] != '{' && chars[*i] != '(' {
         *i += 1;
@@ -263,23 +393,20 @@ fn parse_bib_entry(chars: &[char], i: &mut usize) -> Option<BibEntry> {
         skip_bib_block(chars, i);
         return None;
     }
-
     if *i >= chars.len() {
         return None;
     }
-    *i += 1; // skip opening { or (
+    *i += 1;
 
-    // Read citation key
     let key_start = *i;
     while *i < chars.len() && chars[*i] != ',' {
         *i += 1;
     }
     let key: String = chars[key_start..*i].iter().collect::<String>().trim().to_string();
     if *i < chars.len() {
-        *i += 1; // skip comma
+        *i += 1;
     }
 
-    // Read fields until closing }
     let mut fields: HashMap<String, String> = HashMap::new();
     parse_bib_fields(chars, i, &mut fields);
 
@@ -304,38 +431,35 @@ fn parse_bib_entry(chars: &[char], i: &mut usize) -> Option<BibEntry> {
 
 fn parse_bib_fields(chars: &[char], i: &mut usize, fields: &mut HashMap<String, String>) {
     let n = chars.len();
-
     loop {
-        // Skip whitespace and commas
         while *i < n && (chars[*i].is_whitespace() || chars[*i] == ',') {
             *i += 1;
         }
-
         if *i >= n || chars[*i] == '}' || chars[*i] == ')' {
-            if *i < n { *i += 1; }
+            if *i < n {
+                *i += 1;
+            }
             break;
         }
-
-        // Read field name
         let name_start = *i;
         while *i < n && chars[*i] != '=' && chars[*i] != '}' && !chars[*i].is_whitespace() {
             *i += 1;
         }
-        if *i == name_start { break; }
+        if *i == name_start {
+            break;
+        }
         let name: String = chars[name_start..*i]
             .iter()
             .collect::<String>()
             .trim()
             .to_lowercase();
 
-        // Skip whitespace and =
         while *i < n && (chars[*i].is_whitespace() || chars[*i] == '=') {
             *i += 1;
         }
-
-        if *i >= n { break; }
-
-        // Read value
+        if *i >= n {
+            break;
+        }
         let value = match chars[*i] {
             '{' => {
                 *i += 1;
@@ -346,7 +470,6 @@ fn parse_bib_fields(chars: &[char], i: &mut usize, fields: &mut HashMap<String, 
                 read_bib_quoted(chars, i)
             }
             _ => {
-                // Bare value (e.g. year = 2022)
                 let start = *i;
                 while *i < n && chars[*i] != ',' && chars[*i] != '\n' && chars[*i] != '}' {
                     *i += 1;
@@ -354,7 +477,6 @@ fn parse_bib_fields(chars: &[char], i: &mut usize, fields: &mut HashMap<String, 
                 chars[start..*i].iter().collect::<String>().trim().to_string()
             }
         };
-
         if !name.is_empty() {
             fields.insert(name, value);
         }
@@ -366,10 +488,16 @@ fn read_bib_braced(chars: &[char], i: &mut usize) -> String {
     let mut result = String::new();
     while *i < chars.len() {
         match chars[*i] {
-            '{' => { depth += 1; result.push('{'); }
+            '{' => {
+                depth += 1;
+                result.push('{');
+            }
             '}' => {
                 depth -= 1;
-                if depth == 0 { *i += 1; break; }
+                if depth == 0 {
+                    *i += 1;
+                    break;
+                }
                 result.push('}');
             }
             c => result.push(c),
@@ -385,13 +513,19 @@ fn read_bib_quoted(chars: &[char], i: &mut usize) -> String {
         result.push(chars[*i]);
         *i += 1;
     }
-    if *i < chars.len() { *i += 1; }
+    if *i < chars.len() {
+        *i += 1;
+    }
     result
 }
 
 fn skip_bib_block(chars: &[char], i: &mut usize) {
-    while *i < chars.len() && chars[*i] != '{' { *i += 1; }
-    if *i < chars.len() { *i += 1; }
+    while *i < chars.len() && chars[*i] != '{' {
+        *i += 1;
+    }
+    if *i < chars.len() {
+        *i += 1;
+    }
     let mut depth = 1usize;
     while *i < chars.len() && depth > 0 {
         match chars[*i] {
@@ -404,8 +538,8 @@ fn skip_bib_block(chars: &[char], i: &mut usize) {
 }
 
 fn clean_bib_braces(s: &str) -> String {
-    let stripped = s.replace('{', "").replace('}', "");
-    stripped
+    s.replace('{', "")
+        .replace('}', "")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
@@ -415,12 +549,23 @@ fn clean_bib_braces(s: &str) -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    setup_quire_dir();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
+            // Quire home
+            get_quire_dir,
+            get_global_bib,
+            get_global_bib_raw,
+            save_global_bib,
+            get_recent_files,
+            add_recent_file,
+            // Documents
             open_document,
+            open_document_path,
             save_document,
             save_document_as,
             load_bib,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,432 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+// ── Data types ────────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BibEntry {
+    pub key: String,
+    pub entry_type: String,
+    pub title: Option<String>,
+    pub authors: Option<String>,
+    pub year: Option<String>,
+    pub journal: Option<String>,
+    pub doi: Option<String>,
+    pub abstract_text: Option<String>,
+    pub url: Option<String>,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OpenResult {
+    pub path: String,
+    pub content: String,
+    pub frontmatter: FrontmatterFields,
+    pub body: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct FrontmatterFields {
+    pub title: Option<String>,
+    pub authors: Vec<String>,
+    pub date: Option<String>,
+}
+
+// ── Commands ──────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+async fn open_document(
+    app: tauri::AppHandle,
+) -> Result<OpenResult, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("Quarto / Markdown", &["qmd", "md"])
+        .blocking_pick_file()
+        .ok_or("No file selected")?;
+
+    let path_str = path
+        .into_path()
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .to_string();
+
+    let content = fs::read_to_string(&path_str).map_err(|e| e.to_string())?;
+    let (frontmatter, body) = split_frontmatter(&content);
+
+    Ok(OpenResult {
+        path: path_str,
+        content: content.clone(),
+        frontmatter,
+        body,
+    })
+}
+
+#[tauri::command]
+async fn save_document(path: String, content: String) -> Result<(), String> {
+    fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn save_document_as(
+    app: tauri::AppHandle,
+    content: String,
+) -> Result<String, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("Quarto Document", &["qmd"])
+        .set_file_name("untitled.qmd")
+        .blocking_save_file()
+        .ok_or("No file selected")?;
+
+    let path_str = path
+        .into_path()
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .to_string();
+
+    fs::write(&path_str, content).map_err(|e| e.to_string())?;
+    Ok(path_str)
+}
+
+#[tauri::command]
+async fn load_bib(path: String) -> Result<Vec<BibEntry>, String> {
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    Ok(parse_bib(&content))
+}
+
+#[tauri::command]
+async fn find_bib_for_document(doc_path: String) -> Result<Option<String>, String> {
+    let doc = Path::new(&doc_path);
+    let dir = doc.parent().ok_or("Invalid path")?;
+
+    // Common .bib locations relative to the document
+    let candidates = [
+        doc.with_extension("bib"),
+        dir.join("references.bib"),
+        dir.join("bibliography.bib"),
+        dir.join("refs.bib"),
+    ];
+
+    for candidate in &candidates {
+        if candidate.exists() {
+            return Ok(Some(candidate.to_string_lossy().to_string()));
+        }
+    }
+
+    // Walk up one directory level
+    if let Some(parent) = dir.parent() {
+        let up_candidates = [
+            parent.join("references.bib"),
+            parent.join("bibliography.bib"),
+        ];
+        for candidate in &up_candidates {
+            if candidate.exists() {
+                return Ok(Some(candidate.to_string_lossy().to_string()));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+#[tauri::command]
+async fn run_quarto(doc_path: String, format: String) -> Result<String, String> {
+    let output = Command::new("quarto")
+        .args(["render", &doc_path, "--to", &format])
+        .output()
+        .map_err(|e| format!("Failed to run quarto: {e}. Is Quarto installed and on PATH?"))?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        // Return the expected output path
+        let doc = Path::new(&doc_path);
+        let ext = match format.as_str() {
+            "pdf" => "pdf",
+            "docx" => "docx",
+            "html" => "html",
+            _ => "pdf",
+        };
+        let out_path = doc
+            .with_extension(ext)
+            .to_string_lossy()
+            .to_string();
+        Ok(format!("{}\nOutput: {}", stdout.trim(), out_path))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(format!("Quarto error:\n{}", stderr.trim()))
+    }
+}
+
+// ── Frontmatter parsing ───────────────────────────────────────────────────────
+
+fn split_frontmatter(content: &str) -> (FrontmatterFields, String) {
+    if !content.starts_with("---") {
+        return (FrontmatterFields::default(), content.to_string());
+    }
+
+    // Find closing ---
+    let after_open = &content[3..];
+    let close_pos = after_open.find("\n---")
+        .or_else(|| after_open.find("\r\n---"));
+
+    let Some(pos) = close_pos else {
+        return (FrontmatterFields::default(), content.to_string());
+    };
+
+    let yaml = &after_open[..pos];
+    let body_start = pos + 4; // skip "\n---"
+    let body = after_open[body_start..].trim_start().to_string();
+
+    let fields = parse_frontmatter_fields(yaml);
+    (fields, body)
+}
+
+fn parse_frontmatter_fields(yaml: &str) -> FrontmatterFields {
+    let mut title: Option<String> = None;
+    let mut authors: Vec<String> = Vec::new();
+    let mut date: Option<String> = None;
+    let mut in_authors = false;
+
+    for line in yaml.lines() {
+        let trimmed = line.trim();
+
+        if let Some(rest) = trimmed.strip_prefix("title:") {
+            title = Some(clean_yaml_string(rest.trim()));
+            in_authors = false;
+        } else if trimmed == "author:" || trimmed == "authors:" {
+            in_authors = true;
+        } else if let Some(rest) = trimmed.strip_prefix("date:") {
+            date = Some(clean_yaml_string(rest.trim()));
+            in_authors = false;
+        } else if in_authors && trimmed.starts_with('-') {
+            let author = trimmed.trim_start_matches('-').trim();
+            // Handle "- name: ..." vs "- Author Name"
+            if let Some(rest) = author.strip_prefix("name:") {
+                authors.push(clean_yaml_string(rest.trim()));
+            } else if !author.is_empty() {
+                authors.push(clean_yaml_string(author));
+            }
+        } else if !trimmed.starts_with(' ') && !trimmed.starts_with('-') {
+            in_authors = false;
+        }
+    }
+
+    FrontmatterFields { title, authors, date }
+}
+
+fn clean_yaml_string(s: &str) -> String {
+    s.trim_matches('"').trim_matches('\'').to_string()
+}
+
+// ── .bib parser ───────────────────────────────────────────────────────────────
+
+fn parse_bib(content: &str) -> Vec<BibEntry> {
+    let mut entries = Vec::new();
+    let chars: Vec<char> = content.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '@' {
+            i += 1;
+            if let Some(entry) = parse_bib_entry(&chars, &mut i) {
+                entries.push(entry);
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    entries
+}
+
+fn parse_bib_entry(chars: &[char], i: &mut usize) -> Option<BibEntry> {
+    // Read entry type
+    let type_start = *i;
+    while *i < chars.len() && chars[*i] != '{' && chars[*i] != '(' {
+        *i += 1;
+    }
+    let entry_type: String = chars[type_start..*i]
+        .iter()
+        .collect::<String>()
+        .trim()
+        .to_lowercase();
+
+    if matches!(entry_type.as_str(), "comment" | "preamble" | "string") {
+        skip_bib_block(chars, i);
+        return None;
+    }
+
+    if *i >= chars.len() {
+        return None;
+    }
+    *i += 1; // skip opening { or (
+
+    // Read citation key
+    let key_start = *i;
+    while *i < chars.len() && chars[*i] != ',' {
+        *i += 1;
+    }
+    let key: String = chars[key_start..*i].iter().collect::<String>().trim().to_string();
+    if *i < chars.len() {
+        *i += 1; // skip comma
+    }
+
+    // Read fields until closing }
+    let mut fields: HashMap<String, String> = HashMap::new();
+    parse_bib_fields(chars, i, &mut fields);
+
+    Some(BibEntry {
+        key,
+        entry_type,
+        title: fields.get("title").map(|s| clean_bib_braces(s)),
+        authors: fields
+            .get("author")
+            .or_else(|| fields.get("authors"))
+            .map(|s| clean_bib_braces(s)),
+        year: fields.get("year").map(|s| clean_bib_braces(s)),
+        journal: fields
+            .get("journal")
+            .or_else(|| fields.get("journaltitle"))
+            .map(|s| clean_bib_braces(s)),
+        doi: fields.get("doi").map(|s| clean_bib_braces(s)),
+        abstract_text: fields.get("abstract").map(|s| clean_bib_braces(s)),
+        url: fields.get("url").map(|s| clean_bib_braces(s)),
+    })
+}
+
+fn parse_bib_fields(chars: &[char], i: &mut usize, fields: &mut HashMap<String, String>) {
+    let n = chars.len();
+
+    loop {
+        // Skip whitespace and commas
+        while *i < n && (chars[*i].is_whitespace() || chars[*i] == ',') {
+            *i += 1;
+        }
+
+        if *i >= n || chars[*i] == '}' || chars[*i] == ')' {
+            if *i < n { *i += 1; }
+            break;
+        }
+
+        // Read field name
+        let name_start = *i;
+        while *i < n && chars[*i] != '=' && chars[*i] != '}' && !chars[*i].is_whitespace() {
+            *i += 1;
+        }
+        if *i == name_start { break; }
+        let name: String = chars[name_start..*i]
+            .iter()
+            .collect::<String>()
+            .trim()
+            .to_lowercase();
+
+        // Skip whitespace and =
+        while *i < n && (chars[*i].is_whitespace() || chars[*i] == '=') {
+            *i += 1;
+        }
+
+        if *i >= n { break; }
+
+        // Read value
+        let value = match chars[*i] {
+            '{' => {
+                *i += 1;
+                read_bib_braced(chars, i)
+            }
+            '"' => {
+                *i += 1;
+                read_bib_quoted(chars, i)
+            }
+            _ => {
+                // Bare value (e.g. year = 2022)
+                let start = *i;
+                while *i < n && chars[*i] != ',' && chars[*i] != '\n' && chars[*i] != '}' {
+                    *i += 1;
+                }
+                chars[start..*i].iter().collect::<String>().trim().to_string()
+            }
+        };
+
+        if !name.is_empty() {
+            fields.insert(name, value);
+        }
+    }
+}
+
+fn read_bib_braced(chars: &[char], i: &mut usize) -> String {
+    let mut depth = 1usize;
+    let mut result = String::new();
+    while *i < chars.len() {
+        match chars[*i] {
+            '{' => { depth += 1; result.push('{'); }
+            '}' => {
+                depth -= 1;
+                if depth == 0 { *i += 1; break; }
+                result.push('}');
+            }
+            c => result.push(c),
+        }
+        *i += 1;
+    }
+    result
+}
+
+fn read_bib_quoted(chars: &[char], i: &mut usize) -> String {
+    let mut result = String::new();
+    while *i < chars.len() && chars[*i] != '"' {
+        result.push(chars[*i]);
+        *i += 1;
+    }
+    if *i < chars.len() { *i += 1; }
+    result
+}
+
+fn skip_bib_block(chars: &[char], i: &mut usize) {
+    while *i < chars.len() && chars[*i] != '{' { *i += 1; }
+    if *i < chars.len() { *i += 1; }
+    let mut depth = 1usize;
+    while *i < chars.len() && depth > 0 {
+        match chars[*i] {
+            '{' => depth += 1,
+            '}' => depth -= 1,
+            _ => {}
+        }
+        *i += 1;
+    }
+}
+
+fn clean_bib_braces(s: &str) -> String {
+    let stripped = s.replace('{', "").replace('}', "");
+    stripped
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ── App entry ─────────────────────────────────────────────────────────────────
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_shell::init())
+        .invoke_handler(tauri::generate_handler![
+            open_document,
+            save_document,
+            save_document_as,
+            load_bib,
+            find_bib_for_document,
+            run_quarto,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,9 @@
+mod library;
+pub use library::{
+    create_library_item, delete_library_item, get_library_item, get_library_items,
+    search_library_items, update_library_item,
+};
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -17,6 +23,19 @@ pub struct BibEntry {
     pub doi: Option<String>,
     pub abstract_text: Option<String>,
     pub url: Option<String>,
+    pub volume: Option<String>,
+    pub issue: Option<String>,
+    pub pages: Option<String>,
+    pub publisher: Option<String>,
+    pub booktitle: Option<String>,
+    pub edition: Option<String>,
+    pub month: Option<String>,
+    pub keywords: Option<String>,
+    pub note: Option<String>,
+    pub isbn: Option<String>,
+    pub issn: Option<String>,
+    pub number: Option<String>,
+    pub institution: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -114,6 +133,12 @@ fn setup_quire_dir() {
     if !recent.exists() {
         fs::write(&recent, "[]").ok();
     }
+
+    // Initialise SQLite library; migrate existing .bib on first run
+    let seed_entries = fs::read_to_string(&global_bib_path())
+        .map(|c| parse_bib(&c))
+        .unwrap_or_default();
+    library::init_library(&seed_entries);
 }
 
 // ── Quire dir commands ────────────────────────────────────────────────────────
@@ -410,22 +435,30 @@ fn parse_bib_entry(chars: &[char], i: &mut usize) -> Option<BibEntry> {
     let mut fields: HashMap<String, String> = HashMap::new();
     parse_bib_fields(chars, i, &mut fields);
 
+    let get = |k: &str| fields.get(k).map(|s| clean_bib_braces(s));
     Some(BibEntry {
         key,
         entry_type,
-        title: fields.get("title").map(|s| clean_bib_braces(s)),
-        authors: fields
-            .get("author")
-            .or_else(|| fields.get("authors"))
-            .map(|s| clean_bib_braces(s)),
-        year: fields.get("year").map(|s| clean_bib_braces(s)),
-        journal: fields
-            .get("journal")
-            .or_else(|| fields.get("journaltitle"))
-            .map(|s| clean_bib_braces(s)),
-        doi: fields.get("doi").map(|s| clean_bib_braces(s)),
-        abstract_text: fields.get("abstract").map(|s| clean_bib_braces(s)),
-        url: fields.get("url").map(|s| clean_bib_braces(s)),
+        title:         get("title"),
+        authors:       fields.get("author").or_else(|| fields.get("authors")).map(|s| clean_bib_braces(s)),
+        year:          get("year"),
+        journal:       fields.get("journal").or_else(|| fields.get("journaltitle")).map(|s| clean_bib_braces(s)),
+        doi:           get("doi"),
+        abstract_text: get("abstract"),
+        url:           get("url"),
+        volume:        get("volume"),
+        issue:         get("issue"),
+        pages:         get("pages"),
+        publisher:     get("publisher"),
+        booktitle:     get("booktitle"),
+        edition:       get("edition"),
+        month:         get("month"),
+        keywords:      get("keywords"),
+        note:          get("note"),
+        isbn:          get("isbn"),
+        issn:          get("issn"),
+        number:        get("number"),
+        institution:   get("institution"),
     })
 }
 
@@ -571,6 +604,13 @@ pub fn run() {
             load_bib,
             find_bib_for_document,
             run_quarto,
+            // Library (SQLite)
+            get_library_items,
+            get_library_item,
+            create_library_item,
+            update_library_item,
+            delete_library_item,
+            search_library_items,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,10 @@ pub use library::{
     get_item_collection_ids, remove_item_from_collection, rename_collection,
     // tags
     create_tag, delete_tag, get_tags, set_item_tags, update_tag_color,
+    // import / export
+    import_bib_file, export_bib_file,
+    // metadata fetch
+    fetch_doi_metadata, fetch_arxiv_metadata, fetch_isbn_metadata,
 };
 
 use serde::{Deserialize, Serialize};
@@ -312,6 +316,35 @@ async fn find_bib_for_document(doc_path: String) -> Result<Option<String>, Strin
 }
 
 #[tauri::command]
+async fn pick_import_bib(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("BibTeX", &["bib"])
+        .blocking_pick_file();
+    match path {
+        Some(p) => Ok(Some(p.into_path().map_err(|e| e.to_string())?.to_string_lossy().to_string())),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+async fn pick_export_bib(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let path = app
+        .dialog()
+        .file()
+        .add_filter("BibTeX", &["bib"])
+        .set_file_name("references.bib")
+        .blocking_save_file();
+    match path {
+        Some(p) => Ok(Some(p.into_path().map_err(|e| e.to_string())?.to_string_lossy().to_string())),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
 async fn run_quarto(doc_path: String, format: String) -> Result<String, String> {
     let output = Command::new("quarto")
         .args(["render", &doc_path, "--to", &format])
@@ -392,7 +425,7 @@ fn clean_yaml_string(s: &str) -> String {
 
 // ── .bib parser ───────────────────────────────────────────────────────────────
 
-fn parse_bib(content: &str) -> Vec<BibEntry> {
+pub(crate) fn parse_bib(content: &str) -> Vec<BibEntry> {
     let mut entries = Vec::new();
     let chars: Vec<char> = content.chars().collect();
     let mut i = 0;
@@ -603,6 +636,8 @@ pub fn run() {
             get_recent_files,
             add_recent_file,
             // Documents
+            pick_import_bib,
+            pick_export_bib,
             open_document,
             open_document_path,
             save_document,
@@ -631,6 +666,13 @@ pub fn run() {
             update_tag_color,
             delete_tag,
             set_item_tags,
+            // Library — import / export
+            import_bib_file,
+            export_bib_file,
+            // Library — metadata fetch
+            fetch_doi_metadata,
+            fetch_arxiv_metadata,
+            fetch_isbn_metadata,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ pub use library::{
     pick_and_attach_file, get_item_attachments, read_attachment_bytes,
     open_attachment_external, remove_attachment,
     // annotations
-    create_annotation, get_annotations_for_attachment,
+    create_annotation, get_annotations_for_attachment, get_all_annotations,
     delete_annotation, update_annotation_note,
 };
 
@@ -688,6 +688,7 @@ pub fn run() {
             // Library — annotations
             create_annotation,
             get_annotations_for_attachment,
+            get_all_annotations,
             delete_annotation,
             update_annotation_note,
         ])

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -1,0 +1,459 @@
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::BibEntry;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LibraryItem {
+    pub id: i64,
+    pub key: String,
+    pub entry_type: String,
+    pub title: Option<String>,
+    pub authors: Option<String>,
+    pub year: Option<String>,
+    pub journal: Option<String>,
+    pub doi: Option<String>,
+    pub abstract_text: Option<String>,
+    pub url: Option<String>,
+    pub volume: Option<String>,
+    pub issue: Option<String>,
+    pub pages: Option<String>,
+    pub publisher: Option<String>,
+    pub booktitle: Option<String>,
+    pub edition: Option<String>,
+    pub month: Option<String>,
+    pub keywords: Option<String>,
+    pub note: Option<String>,
+    pub isbn: Option<String>,
+    pub issn: Option<String>,
+    pub number: Option<String>,
+    pub institution: Option<String>,
+    pub added_at: i64,
+    pub updated_at: i64,
+    pub tags: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemInput {
+    pub key: String,
+    pub entry_type: String,
+    pub title: Option<String>,
+    pub authors: Option<String>,
+    pub year: Option<String>,
+    pub journal: Option<String>,
+    pub doi: Option<String>,
+    pub abstract_text: Option<String>,
+    pub url: Option<String>,
+    pub volume: Option<String>,
+    pub issue: Option<String>,
+    pub pages: Option<String>,
+    pub publisher: Option<String>,
+    pub booktitle: Option<String>,
+    pub edition: Option<String>,
+    pub month: Option<String>,
+    pub keywords: Option<String>,
+    pub note: Option<String>,
+    pub isbn: Option<String>,
+    pub issn: Option<String>,
+    pub number: Option<String>,
+    pub institution: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchQuery {
+    pub text: Option<String>,
+    pub entry_types: Option<Vec<String>>,
+    pub year_min: Option<String>,
+    pub year_max: Option<String>,
+    pub has_doi: Option<bool>,
+}
+
+// ── Path helpers ──────────────────────────────────────────────────────────────
+
+fn library_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".quire")
+        .join("library.db")
+}
+
+fn bib_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".quire")
+        .join("references.bib")
+}
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+fn open_conn() -> Result<Connection, String> {
+    let conn = Connection::open(library_db_path()).map_err(|e| e.to_string())?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        .map_err(|e| e.to_string())?;
+    Ok(conn)
+}
+
+fn init_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS items (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            key           TEXT    NOT NULL UNIQUE,
+            entry_type    TEXT    NOT NULL DEFAULT 'misc',
+            title         TEXT,
+            authors       TEXT,
+            year          TEXT,
+            journal       TEXT,
+            doi           TEXT,
+            abstract_text TEXT,
+            url           TEXT,
+            volume        TEXT,
+            issue         TEXT,
+            pages         TEXT,
+            publisher     TEXT,
+            booktitle     TEXT,
+            edition       TEXT,
+            month         TEXT,
+            keywords      TEXT,
+            note          TEXT,
+            isbn          TEXT,
+            issn          TEXT,
+            number        TEXT,
+            institution   TEXT,
+            added_at      INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+            updated_at    INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS collections (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            name       TEXT    NOT NULL,
+            parent_id  INTEGER REFERENCES collections(id) ON DELETE SET NULL,
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_items (
+            collection_id INTEGER NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+            item_id       INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            PRIMARY KEY (collection_id, item_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS tags (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            name  TEXT    NOT NULL UNIQUE,
+            color TEXT    NOT NULL DEFAULT '#888888'
+        );
+
+        CREATE TABLE IF NOT EXISTS item_tags (
+            item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            tag_id  INTEGER NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+            PRIMARY KEY (item_id, tag_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS trash (
+            item_id    INTEGER NOT NULL PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+            deleted_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );",
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn row_to_item(row: &rusqlite::Row) -> rusqlite::Result<LibraryItem> {
+    Ok(LibraryItem {
+        id:            row.get(0)?,
+        key:           row.get(1)?,
+        entry_type:    row.get(2)?,
+        title:         row.get(3)?,
+        authors:       row.get(4)?,
+        year:          row.get(5)?,
+        journal:       row.get(6)?,
+        doi:           row.get(7)?,
+        abstract_text: row.get(8)?,
+        url:           row.get(9)?,
+        volume:        row.get(10)?,
+        issue:         row.get(11)?,
+        pages:         row.get(12)?,
+        publisher:     row.get(13)?,
+        booktitle:     row.get(14)?,
+        edition:       row.get(15)?,
+        month:         row.get(16)?,
+        keywords:      row.get(17)?,
+        note:          row.get(18)?,
+        isbn:          row.get(19)?,
+        issn:          row.get(20)?,
+        number:        row.get(21)?,
+        institution:   row.get(22)?,
+        added_at:      row.get(23)?,
+        updated_at:    row.get(24)?,
+        tags:          vec![],
+    })
+}
+
+fn fetch_item(conn: &Connection, id: i64) -> Result<Option<LibraryItem>, String> {
+    conn.query_row(
+        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
+                isbn, issn, number, institution, added_at, updated_at
+         FROM items WHERE id=?1",
+        [id],
+        |row| row_to_item(row),
+    )
+    .optional()
+    .map_err(|e| e.to_string())
+}
+
+// ── Migration helpers ─────────────────────────────────────────────────────────
+
+fn migrate_entries(conn: &Connection, entries: &[BibEntry]) -> Result<(), String> {
+    for e in entries {
+        conn.execute(
+            "INSERT OR IGNORE INTO items
+             (key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+              volume, issue, pages, publisher, booktitle, edition, month, keywords,
+              note, isbn, issn, number, institution)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)",
+            params![
+                e.key, e.entry_type, e.title, e.authors, e.year, e.journal,
+                e.doi, e.abstract_text, e.url, e.volume, e.issue, e.pages,
+                e.publisher, e.booktitle, e.edition, e.month, e.keywords,
+                e.note, e.isbn, e.issn, e.number, e.institution
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+// ── BibTeX serialiser (for backward-compat .bib regeneration) ─────────────────
+
+fn items_to_bib(items: &[LibraryItem]) -> String {
+    let mut out = String::from(
+        "% Quire global bibliography — ~/.quire/references.bib\n\
+         % Managed by Quire. Edit via the Library view.\n\n",
+    );
+    for item in items {
+        out.push_str(&format!("@{}{{{}", item.entry_type, item.key));
+
+        macro_rules! field {
+            ($name:literal, $opt:expr) => {
+                if let Some(ref v) = $opt {
+                    out.push_str(&format!(",\n  {:13} = {{{}}}", $name, v));
+                }
+            };
+        }
+
+        field!("title",       item.title);
+        field!("author",      item.authors);
+        field!("year",        item.year);
+        field!("journal",     item.journal);
+        field!("booktitle",   item.booktitle);
+        field!("volume",      item.volume);
+        field!("number",      item.number);
+        field!("issue",       item.issue);
+        field!("pages",       item.pages);
+        field!("publisher",   item.publisher);
+        field!("institution", item.institution);
+        field!("edition",     item.edition);
+        field!("month",       item.month);
+        field!("isbn",        item.isbn);
+        field!("issn",        item.issn);
+        field!("doi",         item.doi);
+        field!("url",         item.url);
+        field!("keywords",    item.keywords);
+        field!("abstract",    item.abstract_text);
+        field!("note",        item.note);
+
+        out.push_str("\n}\n\n");
+    }
+    out
+}
+
+fn regenerate_bib(conn: &Connection) -> Result<(), String> {
+    let mut stmt = conn.prepare(
+        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
+                isbn, issn, number, institution, added_at, updated_at
+         FROM items WHERE id NOT IN (SELECT item_id FROM trash) ORDER BY added_at ASC",
+    )
+    .map_err(|e| e.to_string())?;
+    let items: Vec<LibraryItem> = stmt
+        .query_map([], |row| row_to_item(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<_, _>>()
+        .map_err(|e| e.to_string())?;
+    fs::write(bib_path(), items_to_bib(&items)).map_err(|e| e.to_string())
+}
+
+// ── Public init (called from lib.rs) ─────────────────────────────────────────
+
+pub fn init_library(bib_entries: &[BibEntry]) {
+    let Ok(conn) = open_conn() else { return };
+    if init_schema(&conn).is_err() {
+        return;
+    }
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM items", [], |r| r.get(0))
+        .unwrap_or(0);
+    if count == 0 && !bib_entries.is_empty() {
+        let _ = migrate_entries(&conn, bib_entries);
+    }
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn get_library_items() -> Result<Vec<LibraryItem>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+                    volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
+                    isbn, issn, number, institution, added_at, updated_at
+             FROM items WHERE id NOT IN (SELECT item_id FROM trash) ORDER BY added_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let items = stmt
+        .query_map([], |row| row_to_item(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(items)
+}
+
+#[tauri::command]
+pub fn get_library_item(id: i64) -> Result<Option<LibraryItem>, String> {
+    let conn = open_conn()?;
+    fetch_item(&conn, id)
+}
+
+#[tauri::command]
+pub fn create_library_item(item: ItemInput) -> Result<LibraryItem, String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT INTO items
+         (key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+          volume, issue, pages, publisher, booktitle, edition, month, keywords,
+          note, isbn, issn, number, institution)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)",
+        params![
+            item.key, item.entry_type, item.title, item.authors, item.year,
+            item.journal, item.doi, item.abstract_text, item.url, item.volume,
+            item.issue, item.pages, item.publisher, item.booktitle, item.edition,
+            item.month, item.keywords, item.note, item.isbn, item.issn,
+            item.number, item.institution
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    let id = conn.last_insert_rowid();
+    let created = fetch_item(&conn, id)?.ok_or("Item not found after insert")?;
+    regenerate_bib(&conn)?;
+    Ok(created)
+}
+
+#[tauri::command]
+pub fn update_library_item(id: i64, item: ItemInput) -> Result<LibraryItem, String> {
+    let conn = open_conn()?;
+    let rows = conn
+        .execute(
+            "UPDATE items SET
+             entry_type=?1, title=?2, authors=?3, year=?4, journal=?5, doi=?6,
+             abstract_text=?7, url=?8, volume=?9, issue=?10, pages=?11,
+             publisher=?12, booktitle=?13, edition=?14, month=?15, keywords=?16,
+             note=?17, isbn=?18, issn=?19, number=?20, institution=?21,
+             updated_at=strftime('%s','now')
+             WHERE id=?22",
+            params![
+                item.entry_type, item.title, item.authors, item.year, item.journal,
+                item.doi, item.abstract_text, item.url, item.volume, item.issue,
+                item.pages, item.publisher, item.booktitle, item.edition, item.month,
+                item.keywords, item.note, item.isbn, item.issn, item.number,
+                item.institution, id
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    if rows == 0 {
+        return Err(format!("Item {} not found", id));
+    }
+    let updated = fetch_item(&conn, id)?.ok_or("Item not found after update")?;
+    regenerate_bib(&conn)?;
+    Ok(updated)
+}
+
+#[tauri::command]
+pub fn delete_library_item(id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute("DELETE FROM items WHERE id=?1", [id])
+        .map_err(|e| e.to_string())?;
+    regenerate_bib(&conn)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn search_library_items(query: SearchQuery) -> Result<Vec<LibraryItem>, String> {
+    let conn = open_conn()?;
+
+    let mut conditions = vec!["id NOT IN (SELECT item_id FROM trash)".to_string()];
+    let mut bind_strs: Vec<String> = vec![];
+
+    if let Some(ref text) = query.text {
+        if !text.is_empty() {
+            let n = bind_strs.len() + 1;
+            conditions.push(format!(
+                "(title LIKE ?{n} OR authors LIKE ?{n} OR key LIKE ?{n} OR abstract_text LIKE ?{n})"
+            ));
+            bind_strs.push(format!("%{}%", text));
+        }
+    }
+
+    if let Some(ref min) = query.year_min {
+        let n = bind_strs.len() + 1;
+        conditions.push(format!("year >= ?{n}"));
+        bind_strs.push(min.clone());
+    }
+
+    if let Some(ref max) = query.year_max {
+        let n = bind_strs.len() + 1;
+        conditions.push(format!("year <= ?{n}"));
+        bind_strs.push(max.clone());
+    }
+
+    if let Some(true) = query.has_doi {
+        conditions.push("doi IS NOT NULL AND doi != ''".to_string());
+    }
+
+    if let Some(ref types) = query.entry_types {
+        if !types.is_empty() {
+            let start = bind_strs.len() + 1;
+            let placeholders: Vec<String> = (start..start + types.len())
+                .map(|i| format!("?{i}"))
+                .collect();
+            conditions.push(format!("entry_type IN ({})", placeholders.join(",")));
+            bind_strs.extend(types.iter().cloned());
+        }
+    }
+
+    let sql = format!(
+        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
+                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
+                isbn, issn, number, institution, added_at, updated_at
+         FROM items WHERE {} ORDER BY added_at DESC",
+        conditions.join(" AND ")
+    );
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let refs: Vec<&dyn rusqlite::types::ToSql> = bind_strs
+        .iter()
+        .map(|s| s as &dyn rusqlite::types::ToSql)
+        .collect();
+    let items = stmt
+        .query_map(refs.as_slice(), |row| row_to_item(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(items)
+}

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -95,6 +95,46 @@ pub struct Tag {
     pub color: String,
 }
 
+// ── Attachment / Annotation types ────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Attachment {
+    pub id:        i64,
+    pub item_id:   i64,
+    pub file_name: String,
+    pub file_path: String,
+    pub added_at:  i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Annotation {
+    pub id:            i64,
+    pub item_id:       i64,
+    pub attachment_id: i64,
+    pub page:          i64,
+    pub ann_type:      String,
+    pub color:         String,
+    pub selected_text: Option<String>,
+    pub note_text:     Option<String>,
+    pub position_json: String,
+    pub created_at:    i64,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationInput {
+    pub item_id:       i64,
+    pub attachment_id: i64,
+    pub page:          i64,
+    pub ann_type:      String,
+    pub color:         String,
+    pub selected_text: Option<String>,
+    pub note_text:     Option<String>,
+    pub position_json: String,
+}
+
 // ── Path helpers ──────────────────────────────────────────────────────────────
 
 fn library_db_path() -> PathBuf {
@@ -109,6 +149,14 @@ fn bib_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".quire")
         .join("references.bib")
+}
+
+fn attachments_dir(item_id: i64) -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".quire")
+        .join("attachments")
+        .join(item_id.to_string())
 }
 
 // ── DB helpers ────────────────────────────────────────────────────────────────
@@ -178,6 +226,27 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
         CREATE TABLE IF NOT EXISTS trash (
             item_id    INTEGER NOT NULL PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
             deleted_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS attachments (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_id   INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            file_name TEXT    NOT NULL,
+            file_path TEXT    NOT NULL,
+            added_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS annotations (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            item_id        INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+            attachment_id  INTEGER NOT NULL REFERENCES attachments(id) ON DELETE CASCADE,
+            page           INTEGER NOT NULL,
+            ann_type       TEXT    NOT NULL DEFAULT 'highlight',
+            color          TEXT    NOT NULL DEFAULT '#FACC15',
+            selected_text  TEXT,
+            note_text      TEXT,
+            position_json  TEXT    NOT NULL DEFAULT '{}',
+            created_at     INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
         );",
     )
     .map_err(|e| e.to_string())
@@ -1097,4 +1166,181 @@ pub async fn fetch_isbn_metadata(isbn: String) -> Result<FetchedMetadata, String
         entry_type: Some("book".to_string()),
         ..Default::default()
     })
+}
+
+// ── Attachments ───────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn pick_and_attach_file(
+    app: tauri::AppHandle,
+    item_id: i64,
+) -> Result<Option<Attachment>, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let picked = app
+        .dialog()
+        .file()
+        .add_filter("PDF files", &["pdf", "PDF"])
+        .blocking_pick_file();
+    let Some(p) = picked else { return Ok(None) };
+    let src = p.into_path().map_err(|e| e.to_string())?;
+
+    let file_name = src
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("attachment.pdf")
+        .to_string();
+
+    let dest_dir = attachments_dir(item_id);
+    fs::create_dir_all(&dest_dir).map_err(|e| e.to_string())?;
+    let dest = dest_dir.join(&file_name);
+    fs::copy(&src, &dest).map_err(|e| e.to_string())?;
+
+    let dest_str = dest.to_string_lossy().to_string();
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT INTO attachments (item_id, file_name, file_path) VALUES (?1, ?2, ?3)",
+        params![item_id, file_name, dest_str],
+    )
+    .map_err(|e| e.to_string())?;
+
+    let id = conn.last_insert_rowid();
+    let added_at: i64 = conn
+        .query_row("SELECT added_at FROM attachments WHERE id=?1", [id], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+
+    Ok(Some(Attachment { id, item_id, file_name, file_path: dest_str, added_at }))
+}
+
+#[tauri::command]
+pub fn get_item_attachments(item_id: i64) -> Result<Vec<Attachment>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, item_id, file_name, file_path, added_at
+             FROM attachments WHERE item_id=?1 ORDER BY added_at",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([item_id], |row| {
+            Ok(Attachment {
+                id:        row.get(0)?,
+                item_id:   row.get(1)?,
+                file_name: row.get(2)?,
+                file_path: row.get(3)?,
+                added_at:  row.get(4)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn read_attachment_bytes(id: i64) -> Result<Vec<u8>, String> {
+    let conn = open_conn()?;
+    let path: String = conn
+        .query_row("SELECT file_path FROM attachments WHERE id=?1", [id], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+    fs::read(&path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn open_attachment_external(app: tauri::AppHandle, id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    let path: String = conn
+        .query_row("SELECT file_path FROM attachments WHERE id=?1", [id], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+    use tauri_plugin_opener::OpenerExt;
+    let url = format!("file:///{}", path.replace('\\', "/"));
+    app.opener()
+        .open_url(&url, None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn remove_attachment(id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    let path: String = conn
+        .query_row("SELECT file_path FROM attachments WHERE id=?1", [id], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+    conn.execute("DELETE FROM attachments WHERE id=?1", [id])
+        .map_err(|e| e.to_string())?;
+    let _ = fs::remove_file(&path);
+    Ok(())
+}
+
+// ── Annotations ───────────────────────────────────────────────────────────────
+
+fn row_to_annotation(row: &rusqlite::Row) -> rusqlite::Result<Annotation> {
+    Ok(Annotation {
+        id:            row.get(0)?,
+        item_id:       row.get(1)?,
+        attachment_id: row.get(2)?,
+        page:          row.get(3)?,
+        ann_type:      row.get(4)?,
+        color:         row.get(5)?,
+        selected_text: row.get(6)?,
+        note_text:     row.get(7)?,
+        position_json: row.get(8)?,
+        created_at:    row.get(9)?,
+    })
+}
+
+const ANN_SELECT: &str =
+    "SELECT id, item_id, attachment_id, page, ann_type, color,
+            selected_text, note_text, position_json, created_at
+     FROM annotations";
+
+#[tauri::command]
+pub fn create_annotation(input: AnnotationInput) -> Result<Annotation, String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT INTO annotations
+             (item_id, attachment_id, page, ann_type, color,
+              selected_text, note_text, position_json)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+        params![
+            input.item_id, input.attachment_id, input.page,
+            input.ann_type, input.color,
+            input.selected_text, input.note_text, input.position_json
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    let id = conn.last_insert_rowid();
+    let sql = format!("{} WHERE id=?1", ANN_SELECT);
+    conn.query_row(&sql, [id], row_to_annotation)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_annotations_for_attachment(attachment_id: i64) -> Result<Vec<Annotation>, String> {
+    let conn = open_conn()?;
+    let sql = format!("{} WHERE attachment_id=?1 ORDER BY page, created_at", ANN_SELECT);
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([attachment_id], row_to_annotation)
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
+}
+
+#[tauri::command]
+pub fn delete_annotation(id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute("DELETE FROM annotations WHERE id=?1", [id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn update_annotation_note(id: i64, note_text: String) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "UPDATE annotations SET note_text=?1 WHERE id=?2",
+        params![note_text, id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, types::Value, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -73,6 +73,26 @@ pub struct SearchQuery {
     pub year_min: Option<String>,
     pub year_max: Option<String>,
     pub has_doi: Option<bool>,
+    pub collection_id: Option<i64>,
+    pub tag_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Collection {
+    pub id: i64,
+    pub name: String,
+    pub parent_id: Option<i64>,
+    pub created_at: i64,
+    pub item_count: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Tag {
+    pub id: i64,
+    pub name: String,
+    pub color: String,
 }
 
 // ── Path helpers ──────────────────────────────────────────────────────────────
@@ -164,6 +184,12 @@ fn init_schema(conn: &Connection) -> Result<(), String> {
 }
 
 fn row_to_item(row: &rusqlite::Row) -> rusqlite::Result<LibraryItem> {
+    let tag_csv: String = row.get(25)?;
+    let tags: Vec<String> = tag_csv
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
     Ok(LibraryItem {
         id:            row.get(0)?,
         key:           row.get(1)?,
@@ -190,21 +216,25 @@ fn row_to_item(row: &rusqlite::Row) -> rusqlite::Result<LibraryItem> {
         institution:   row.get(22)?,
         added_at:      row.get(23)?,
         updated_at:    row.get(24)?,
-        tags:          vec![],
+        tags,
     })
 }
 
+const ITEM_SELECT: &str =
+    "SELECT i.id, i.key, i.entry_type, i.title, i.authors, i.year, i.journal, i.doi,
+            i.abstract_text, i.url, i.volume, i.issue, i.pages, i.publisher, i.booktitle,
+            i.edition, i.month, i.keywords, i.note, i.isbn, i.issn, i.number, i.institution,
+            i.added_at, i.updated_at,
+            COALESCE(GROUP_CONCAT(DISTINCT t.name), '') as tag_names
+     FROM items i
+     LEFT JOIN item_tags it ON it.item_id = i.id
+     LEFT JOIN tags t ON t.id = it.tag_id";
+
 fn fetch_item(conn: &Connection, id: i64) -> Result<Option<LibraryItem>, String> {
-    conn.query_row(
-        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
-                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
-                isbn, issn, number, institution, added_at, updated_at
-         FROM items WHERE id=?1",
-        [id],
-        |row| row_to_item(row),
-    )
-    .optional()
-    .map_err(|e| e.to_string())
+    let sql = format!("{} WHERE i.id=?1 GROUP BY i.id", ITEM_SELECT);
+    conn.query_row(&sql, [id], |row| row_to_item(row))
+        .optional()
+        .map_err(|e| e.to_string())
 }
 
 // ── Migration helpers ─────────────────────────────────────────────────────────
@@ -274,13 +304,11 @@ fn items_to_bib(items: &[LibraryItem]) -> String {
 }
 
 fn regenerate_bib(conn: &Connection) -> Result<(), String> {
-    let mut stmt = conn.prepare(
-        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
-                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
-                isbn, issn, number, institution, added_at, updated_at
-         FROM items WHERE id NOT IN (SELECT item_id FROM trash) ORDER BY added_at ASC",
-    )
-    .map_err(|e| e.to_string())?;
+    let sql = format!(
+        "{} WHERE i.id NOT IN (SELECT item_id FROM trash) GROUP BY i.id ORDER BY i.added_at ASC",
+        ITEM_SELECT
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
     let items: Vec<LibraryItem> = stmt
         .query_map([], |row| row_to_item(row))
         .map_err(|e| e.to_string())?
@@ -309,14 +337,11 @@ pub fn init_library(bib_entries: &[BibEntry]) {
 #[tauri::command]
 pub fn get_library_items() -> Result<Vec<LibraryItem>, String> {
     let conn = open_conn()?;
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
-                    volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
-                    isbn, issn, number, institution, added_at, updated_at
-             FROM items WHERE id NOT IN (SELECT item_id FROM trash) ORDER BY added_at DESC",
-        )
-        .map_err(|e| e.to_string())?;
+    let sql = format!(
+        "{} WHERE i.id NOT IN (SELECT item_id FROM trash) GROUP BY i.id ORDER BY i.added_at DESC",
+        ITEM_SELECT
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
     let items = stmt
         .query_map([], |row| row_to_item(row))
         .map_err(|e| e.to_string())?
@@ -397,63 +422,268 @@ pub fn delete_library_item(id: i64) -> Result<(), String> {
 pub fn search_library_items(query: SearchQuery) -> Result<Vec<LibraryItem>, String> {
     let conn = open_conn()?;
 
-    let mut conditions = vec!["id NOT IN (SELECT item_id FROM trash)".to_string()];
-    let mut bind_strs: Vec<String> = vec![];
+    let mut conditions = vec!["i.id NOT IN (SELECT item_id FROM trash)".to_string()];
+    let mut binds: Vec<Value> = vec![];
 
     if let Some(ref text) = query.text {
         if !text.is_empty() {
-            let n = bind_strs.len() + 1;
+            let n = binds.len() + 1;
             conditions.push(format!(
-                "(title LIKE ?{n} OR authors LIKE ?{n} OR key LIKE ?{n} OR abstract_text LIKE ?{n})"
+                "(i.title LIKE ?{n} OR i.authors LIKE ?{n} OR i.key LIKE ?{n} OR i.abstract_text LIKE ?{n})"
             ));
-            bind_strs.push(format!("%{}%", text));
+            binds.push(Value::Text(format!("%{}%", text)));
         }
     }
 
     if let Some(ref min) = query.year_min {
-        let n = bind_strs.len() + 1;
-        conditions.push(format!("year >= ?{n}"));
-        bind_strs.push(min.clone());
+        let n = binds.len() + 1;
+        conditions.push(format!("i.year >= ?{n}"));
+        binds.push(Value::Text(min.clone()));
     }
 
     if let Some(ref max) = query.year_max {
-        let n = bind_strs.len() + 1;
-        conditions.push(format!("year <= ?{n}"));
-        bind_strs.push(max.clone());
+        let n = binds.len() + 1;
+        conditions.push(format!("i.year <= ?{n}"));
+        binds.push(Value::Text(max.clone()));
     }
 
     if let Some(true) = query.has_doi {
-        conditions.push("doi IS NOT NULL AND doi != ''".to_string());
+        conditions.push("i.doi IS NOT NULL AND i.doi != ''".to_string());
     }
 
     if let Some(ref types) = query.entry_types {
         if !types.is_empty() {
-            let start = bind_strs.len() + 1;
-            let placeholders: Vec<String> = (start..start + types.len())
-                .map(|i| format!("?{i}"))
-                .collect();
-            conditions.push(format!("entry_type IN ({})", placeholders.join(",")));
-            bind_strs.extend(types.iter().cloned());
+            let start = binds.len() + 1;
+            let placeholders: Vec<String> =
+                (start..start + types.len()).map(|i| format!("?{i}")).collect();
+            conditions.push(format!("i.entry_type IN ({})", placeholders.join(",")));
+            for t in types {
+                binds.push(Value::Text(t.clone()));
+            }
+        }
+    }
+
+    if let Some(coll_id) = query.collection_id {
+        let n = binds.len() + 1;
+        conditions.push(format!(
+            "i.id IN (SELECT item_id FROM collection_items WHERE collection_id = ?{n})"
+        ));
+        binds.push(Value::Integer(coll_id));
+    }
+
+    if let Some(ref tag) = query.tag_name {
+        if !tag.is_empty() {
+            let n = binds.len() + 1;
+            conditions.push(format!(
+                "i.id IN (SELECT it2.item_id FROM item_tags it2 JOIN tags t2 ON t2.id=it2.tag_id WHERE t2.name=?{n})"
+            ));
+            binds.push(Value::Text(tag.clone()));
         }
     }
 
     let sql = format!(
-        "SELECT id, key, entry_type, title, authors, year, journal, doi, abstract_text, url,
-                volume, issue, pages, publisher, booktitle, edition, month, keywords, note,
-                isbn, issn, number, institution, added_at, updated_at
-         FROM items WHERE {} ORDER BY added_at DESC",
+        "SELECT i.id, i.key, i.entry_type, i.title, i.authors, i.year, i.journal, i.doi,
+                i.abstract_text, i.url, i.volume, i.issue, i.pages, i.publisher, i.booktitle,
+                i.edition, i.month, i.keywords, i.note, i.isbn, i.issn, i.number, i.institution,
+                i.added_at, i.updated_at,
+                COALESCE(GROUP_CONCAT(DISTINCT t.name), '') as tag_names
+         FROM items i
+         LEFT JOIN item_tags it ON it.item_id = i.id
+         LEFT JOIN tags t ON t.id = it.tag_id
+         WHERE {}
+         GROUP BY i.id ORDER BY i.added_at DESC",
         conditions.join(" AND ")
     );
 
     let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-    let refs: Vec<&dyn rusqlite::types::ToSql> = bind_strs
-        .iter()
-        .map(|s| s as &dyn rusqlite::types::ToSql)
-        .collect();
+    let refs: Vec<&dyn rusqlite::types::ToSql> =
+        binds.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
     let items = stmt
         .query_map(refs.as_slice(), |row| row_to_item(row))
         .map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
     Ok(items)
+}
+
+// ── Collection commands ───────────────────────────────────────────────────────
+
+fn row_to_collection(row: &rusqlite::Row) -> rusqlite::Result<Collection> {
+    Ok(Collection {
+        id:         row.get(0)?,
+        name:       row.get(1)?,
+        parent_id:  row.get(2)?,
+        created_at: row.get(3)?,
+        item_count: row.get(4)?,
+    })
+}
+
+#[tauri::command]
+pub fn get_collections() -> Result<Vec<Collection>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id, c.name, c.parent_id, c.created_at,
+                    COUNT(DISTINCT ci.item_id) as item_count
+             FROM collections c
+             LEFT JOIN collection_items ci ON ci.collection_id = c.id
+             LEFT JOIN items i ON i.id = ci.item_id
+                 AND i.id NOT IN (SELECT item_id FROM trash)
+             GROUP BY c.id ORDER BY c.name COLLATE NOCASE",
+        )
+        .map_err(|e| e.to_string())?;
+    let cols = stmt
+        .query_map([], |row| row_to_collection(row))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(cols)
+}
+
+#[tauri::command]
+pub fn create_collection(name: String, parent_id: Option<i64>) -> Result<Collection, String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT INTO collections (name, parent_id) VALUES (?1, ?2)",
+        params![name, parent_id],
+    )
+    .map_err(|e| e.to_string())?;
+    let id = conn.last_insert_rowid();
+    conn.query_row(
+        "SELECT id, name, parent_id, created_at, 0 FROM collections WHERE id=?1",
+        [id],
+        |row| row_to_collection(row),
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn rename_collection(id: i64, name: String) -> Result<Collection, String> {
+    let conn = open_conn()?;
+    conn.execute("UPDATE collections SET name=?1 WHERE id=?2", params![name, id])
+        .map_err(|e| e.to_string())?;
+    conn.query_row(
+        "SELECT c.id, c.name, c.parent_id, c.created_at,
+                COUNT(DISTINCT ci.item_id) as item_count
+         FROM collections c
+         LEFT JOIN collection_items ci ON ci.collection_id = c.id
+         WHERE c.id=?1 GROUP BY c.id",
+        [id],
+        |row| row_to_collection(row),
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_collection(id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute("DELETE FROM collections WHERE id=?1", [id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn add_item_to_collection(collection_id: i64, item_id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT OR IGNORE INTO collection_items (collection_id, item_id) VALUES (?1, ?2)",
+        params![collection_id, item_id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn remove_item_from_collection(collection_id: i64, item_id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "DELETE FROM collection_items WHERE collection_id=?1 AND item_id=?2",
+        params![collection_id, item_id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_item_collection_ids(item_id: i64) -> Result<Vec<i64>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare("SELECT collection_id FROM collection_items WHERE item_id=?1")
+        .map_err(|e| e.to_string())?;
+    let ids = stmt
+        .query_map([item_id], |row| row.get(0))
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<i64>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(ids)
+}
+
+// ── Tag commands ──────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn get_tags() -> Result<Vec<Tag>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare("SELECT id, name, color FROM tags ORDER BY name COLLATE NOCASE")
+        .map_err(|e| e.to_string())?;
+    let tags = stmt
+        .query_map([], |row| {
+            Ok(Tag { id: row.get(0)?, name: row.get(1)?, color: row.get(2)? })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(tags)
+}
+
+#[tauri::command]
+pub fn create_tag(name: String, color: String) -> Result<Tag, String> {
+    let conn = open_conn()?;
+    conn.execute(
+        "INSERT OR IGNORE INTO tags (name, color) VALUES (?1, ?2)",
+        params![name, color],
+    )
+    .map_err(|e| e.to_string())?;
+    conn.query_row(
+        "SELECT id, name, color FROM tags WHERE name=?1",
+        [&name],
+        |row| Ok(Tag { id: row.get(0)?, name: row.get(1)?, color: row.get(2)? }),
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn update_tag_color(id: i64, color: String) -> Result<Tag, String> {
+    let conn = open_conn()?;
+    conn.execute("UPDATE tags SET color=?1 WHERE id=?2", params![color, id])
+        .map_err(|e| e.to_string())?;
+    conn.query_row(
+        "SELECT id, name, color FROM tags WHERE id=?1",
+        [id],
+        |row| Ok(Tag { id: row.get(0)?, name: row.get(1)?, color: row.get(2)? }),
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_tag(id: i64) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute("DELETE FROM tags WHERE id=?1", [id])
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn set_item_tags(item_id: i64, tag_ids: Vec<i64>) -> Result<(), String> {
+    let conn = open_conn()?;
+    conn.execute("DELETE FROM item_tags WHERE item_id=?1", [item_id])
+        .map_err(|e| e.to_string())?;
+    for tag_id in tag_ids {
+        conn.execute(
+            "INSERT OR IGNORE INTO item_tags (item_id, tag_id) VALUES (?1, ?2)",
+            params![item_id, tag_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(())
 }

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -939,25 +939,42 @@ pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> 
 
     let client = reqwest::Client::builder()
         .user_agent("Quire/1.0 (https://github.com/quire)")
-        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(8))
         .build()
         .map_err(|e| e.to_string())?;
 
     // Try CrossRef first (covers most journal articles and arXiv DOIs)
-    let cr_url = format!("https://api.crossref.org/works/{clean}");
-    if let Ok(resp) = client.get(&cr_url).send().await {
+    let cr_url = format!("https://api.crossref.org/works/{}", clean);
+    let cr_result = tokio::time::timeout(
+        std::time::Duration::from_secs(8),
+        client.get(&cr_url).send(),
+    ).await;
+    if let Ok(Ok(resp)) = cr_result {
         if resp.status().is_success() {
-            if let Ok(json) = resp.json::<serde_json::Value>().await {
+            let json_result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                resp.json::<serde_json::Value>(),
+            ).await;
+            if let Ok(Ok(json)) = json_result {
                 return Ok(parse_crossref_message(&json["message"], &clean));
             }
         }
     }
 
     // Fallback: DataCite API (covers Zenodo, figshare, etc.)
-    let dc_url = format!("https://api.datacite.org/dois/{clean}");
-    if let Ok(resp) = client.get(&dc_url).send().await {
+    let dc_url = format!("https://api.datacite.org/dois/{}", clean);
+    let dc_result = tokio::time::timeout(
+        std::time::Duration::from_secs(8),
+        client.get(&dc_url).send(),
+    ).await;
+    if let Ok(Ok(resp)) = dc_result {
         if resp.status().is_success() {
-            if let Ok(json) = resp.json::<serde_json::Value>().await {
+            let json_result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                resp.json::<serde_json::Value>(),
+            ).await;
+            if let Ok(Ok(json)) = json_result {
                 return Ok(parse_datacite_attrs(&json["data"]["attributes"], &clean));
             }
         }
@@ -978,12 +995,22 @@ pub async fn fetch_arxiv_metadata(arxiv_id: String) -> Result<FetchedMetadata, S
     let url = format!("https://export.arxiv.org/api/query?id_list={clean}");
     let client = reqwest::Client::builder()
         .user_agent("Quire/1.0")
-        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(8))
         .build()
         .map_err(|e| e.to_string())?;
-    let xml = client.get(&url).send().await
-        .map_err(|e| format!("Network error: {e}"))?
-        .text().await.map_err(|e| e.to_string())?;
+    let send_result = tokio::time::timeout(
+        std::time::Duration::from_secs(8),
+        client.get(&url).send(),
+    ).await
+    .map_err(|_| "arXiv request timed out — check your internet connection.".to_string())?
+    .map_err(|e| format!("Network error: {e}"))?;
+    let xml = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        send_result.text(),
+    ).await
+    .map_err(|_| "arXiv response timed out.".to_string())?
+    .map_err(|e| e.to_string())?;
 
     if xml.contains("<opensearch:totalResults>0</opensearch:totalResults>") {
         return Err("arXiv ID not found".to_string());
@@ -1029,12 +1056,22 @@ pub async fn fetch_isbn_metadata(isbn: String) -> Result<FetchedMetadata, String
     );
     let client = reqwest::Client::builder()
         .user_agent("Quire/1.0")
-        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(8))
         .build()
         .map_err(|e| e.to_string())?;
-    let json: serde_json::Value = client.get(&url).send().await
-        .map_err(|e| format!("Network error: {e}"))?
-        .json().await.map_err(|e| e.to_string())?;
+    let send_result = tokio::time::timeout(
+        std::time::Duration::from_secs(8),
+        client.get(&url).send(),
+    ).await
+    .map_err(|_| "OpenLibrary request timed out — check your internet connection.".to_string())?
+    .map_err(|e| format!("Network error: {e}"))?;
+    let json: serde_json::Value = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        send_result.json(),
+    ).await
+    .map_err(|_| "OpenLibrary response timed out.".to_string())?
+    .map_err(|e| e.to_string())?;
 
     let key  = format!("ISBN:{clean}");
     let book = json.get(&key).ok_or("ISBN not found in OpenLibrary")?;

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -122,6 +122,25 @@ pub struct Annotation {
     pub created_at:    i64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnnotationWithSource {
+    pub id:                  i64,
+    pub item_id:             i64,
+    pub attachment_id:       i64,
+    pub page:                i64,
+    pub ann_type:            String,
+    pub color:               String,
+    pub selected_text:       Option<String>,
+    pub note_text:           Option<String>,
+    pub created_at:          i64,
+    pub item_title:          Option<String>,
+    pub item_authors:        Option<String>,
+    pub item_year:           Option<String>,
+    pub item_key:            String,
+    pub attachment_file_name: String,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AnnotationInput {
@@ -1343,4 +1362,44 @@ pub fn update_annotation_note(id: i64, note_text: String) -> Result<(), String> 
     )
     .map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_all_annotations() -> Result<Vec<AnnotationWithSource>, String> {
+    let conn = open_conn()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT a.id, a.item_id, a.attachment_id, a.page, a.ann_type, a.color,
+                    a.selected_text, a.note_text, a.created_at,
+                    i.title, i.authors, i.year, i.key,
+                    att.file_name
+             FROM annotations a
+             JOIN attachments att ON att.id = a.attachment_id
+             JOIN items i ON i.id = a.item_id
+             ORDER BY i.title COLLATE NOCASE, a.page, a.created_at",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(AnnotationWithSource {
+                id:                   row.get(0)?,
+                item_id:              row.get(1)?,
+                attachment_id:        row.get(2)?,
+                page:                 row.get(3)?,
+                ann_type:             row.get(4)?,
+                color:                row.get(5)?,
+                selected_text:        row.get(6)?,
+                note_text:            row.get(7)?,
+                created_at:           row.get(8)?,
+                item_title:           row.get(9)?,
+                item_authors:         row.get(10)?,
+                item_year:            row.get(11)?,
+                item_key:             row.get(12)?,
+                attachment_file_name: row.get(13)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows)
 }

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -939,6 +939,7 @@ pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> 
 
     let client = reqwest::Client::builder()
         .user_agent("Quire/1.0 (https://github.com/quire)")
+        .timeout(std::time::Duration::from_secs(10))
         .build()
         .map_err(|e| e.to_string())?;
 
@@ -975,7 +976,12 @@ pub async fn fetch_arxiv_metadata(arxiv_id: String) -> Result<FetchedMetadata, S
     let clean = raw.split('v').next().unwrap_or(raw).trim();
 
     let url = format!("https://export.arxiv.org/api/query?id_list={clean}");
-    let xml = reqwest::get(&url).await
+    let client = reqwest::Client::builder()
+        .user_agent("Quire/1.0")
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let xml = client.get(&url).send().await
         .map_err(|e| format!("Network error: {e}"))?
         .text().await.map_err(|e| e.to_string())?;
 
@@ -1021,7 +1027,12 @@ pub async fn fetch_isbn_metadata(isbn: String) -> Result<FetchedMetadata, String
     let url = format!(
         "https://openlibrary.org/api/books?bibkeys=ISBN:{clean}&format=json&jscmd=data"
     );
-    let json: serde_json::Value = reqwest::get(&url).await
+    let client = reqwest::Client::builder()
+        .user_agent("Quire/1.0")
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let json: serde_json::Value = client.get(&url).send().await
         .map_err(|e| format!("Network error: {e}"))?
         .json().await.map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -827,37 +827,32 @@ fn xml_tag_text(xml: &str, tag: &str) -> Option<String> {
     if text.is_empty() { None } else { Some(text) }
 }
 
-// ── DOI fetch via CrossRef ────────────────────────────────────────────────────
+// ── DOI fetch — CrossRef + DataCite fallback ─────────────────────────────────
 
-#[tauri::command]
-pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> {
-    let url = format!("https://api.crossref.org/works/{}", doi.trim());
-    let client = reqwest::Client::builder()
-        .user_agent("Quire/1.0 (https://github.com/quire)")
-        .build()
-        .map_err(|e| e.to_string())?;
-
-    let resp = client.get(&url).send().await
-        .map_err(|e| format!("Network error: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("DOI not found (HTTP {})", resp.status().as_u16()));
+fn normalize_doi(raw: &str) -> &str {
+    let s = raw.trim();
+    for prefix in &[
+        "https://doi.org/", "http://doi.org/",
+        "https://dx.doi.org/", "http://dx.doi.org/",
+        "doi:", "DOI:",
+    ] {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            return rest.trim();
+        }
     }
-    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
-    let msg = &json["message"];
+    s
+}
 
+fn parse_crossref_message(msg: &serde_json::Value, fallback_doi: &str) -> FetchedMetadata {
     let title = msg["title"].as_array()
-        .and_then(|a| a.first())
-        .and_then(|v| v.as_str())
-        .map(String::from);
+        .and_then(|a| a.first()).and_then(|v| v.as_str()).map(String::from);
 
     let authors = msg["author"].as_array().map(|arr| {
         arr.iter().filter_map(|a| {
             let fam = a["family"].as_str()?;
             let giv = a["given"].as_str().unwrap_or("");
             Some(if giv.is_empty() { fam.to_string() } else { format!("{fam}, {giv}") })
-        })
-        .collect::<Vec<_>>()
-        .join(" and ")
+        }).collect::<Vec<_>>().join(" and ")
     }).filter(|s| !s.is_empty());
 
     let year = msg["published"]["date-parts"]
@@ -866,29 +861,108 @@ pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> 
         .and_then(|y| y.as_u64()).map(|y| y.to_string());
 
     let journal = msg["container-title"].as_array()
-        .and_then(|a| a.first())
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(String::from);
+        .and_then(|a| a.first()).and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty()).map(String::from);
 
     let volume    = msg["volume"].as_str().map(String::from);
     let issue     = msg["issue"].as_str().map(String::from);
     let pages     = msg["page"].as_str().map(String::from);
     let doi_val   = msg["DOI"].as_str().map(String::from)
-        .unwrap_or_else(|| doi.trim().to_string());
+        .unwrap_or_else(|| fallback_doi.to_string());
     let issn      = msg["ISSN"].as_array()
         .and_then(|a| a.first()).and_then(|v| v.as_str()).map(String::from);
     let publisher = msg["publisher"].as_str().map(String::from);
     let url_val   = msg["URL"].as_str().map(String::from);
     let abstract_text = msg["abstract"].as_str()
         .map(|s| strip_xml_tags(s)).filter(|s| !s.is_empty());
+    let entry_type = match msg["type"].as_str() {
+        Some("journal-article") => Some("article".to_string()),
+        Some("book") | Some("monograph") => Some("book".to_string()),
+        Some("proceedings-article") => Some("inproceedings".to_string()),
+        Some("report") => Some("techreport".to_string()),
+        _ => Some("misc".to_string()),
+    };
 
-    Ok(FetchedMetadata {
+    FetchedMetadata {
         title, authors, year, journal, volume, issue, pages,
         doi: Some(doi_val), issn, publisher, url: url_val, abstract_text,
-        entry_type: Some("article".to_string()),
+        entry_type, ..Default::default()
+    }
+}
+
+fn parse_datacite_attrs(attrs: &serde_json::Value, fallback_doi: &str) -> FetchedMetadata {
+    let title = attrs["titles"].as_array()
+        .and_then(|a| a.first()).and_then(|t| t["title"].as_str()).map(String::from);
+
+    let authors = attrs["creators"].as_array().map(|arr| {
+        arr.iter().filter_map(|c| {
+            let fam = c["familyName"].as_str();
+            let giv = c["givenName"].as_str();
+            match (fam, giv) {
+                (Some(f), Some(g)) => Some(format!("{f}, {g}")),
+                (Some(f), None)    => Some(f.to_string()),
+                _                  => c["name"].as_str().map(String::from),
+            }
+        }).collect::<Vec<_>>().join(" and ")
+    }).filter(|s| !s.is_empty());
+
+    let year = attrs["publicationYear"].as_u64().map(|y| y.to_string());
+    let publisher = attrs["publisher"].as_str().map(String::from);
+    let doi_val   = attrs["doi"].as_str().map(String::from)
+        .unwrap_or_else(|| fallback_doi.to_string());
+
+    let abstract_text = attrs["descriptions"].as_array().and_then(|arr| {
+        arr.iter().find(|d| d["descriptionType"].as_str() == Some("Abstract"))
+            .and_then(|d| d["description"].as_str())
+            .map(|s| strip_xml_tags(s))
+    }).filter(|s| !s.is_empty());
+
+    let entry_type = match attrs["types"]["resourceTypeGeneral"].as_str() {
+        Some("JournalArticle") => Some("article".to_string()),
+        Some("Book")           => Some("book".to_string()),
+        Some("ConferencePaper") => Some("inproceedings".to_string()),
+        Some("Report")         => Some("techreport".to_string()),
+        _                      => Some("misc".to_string()),
+    };
+
+    FetchedMetadata {
+        title, authors, year, publisher,
+        doi: Some(doi_val),
+        abstract_text, entry_type,
         ..Default::default()
-    })
+    }
+}
+
+#[tauri::command]
+pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> {
+    let clean = normalize_doi(&doi).to_string();
+
+    let client = reqwest::Client::builder()
+        .user_agent("Quire/1.0 (https://github.com/quire)")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    // Try CrossRef first (covers most journal articles and arXiv DOIs)
+    let cr_url = format!("https://api.crossref.org/works/{clean}");
+    if let Ok(resp) = client.get(&cr_url).send().await {
+        if resp.status().is_success() {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                return Ok(parse_crossref_message(&json["message"], &clean));
+            }
+        }
+    }
+
+    // Fallback: DataCite API (covers Zenodo, figshare, etc.)
+    let dc_url = format!("https://api.datacite.org/dois/{clean}");
+    if let Ok(resp) = client.get(&dc_url).send().await {
+        if resp.status().is_success() {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                return Ok(parse_datacite_attrs(&json["data"]["attributes"], &clean));
+            }
+        }
+    }
+
+    Err(format!("DOI not found in CrossRef or DataCite: {clean}"))
 }
 
 // ── arXiv fetch ───────────────────────────────────────────────────────────────

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::BibEntry;
+use crate::{BibEntry, parse_bib};
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -686,4 +686,293 @@ pub fn set_item_tags(item_id: i64, tag_ids: Vec<i64>) -> Result<(), String> {
         .map_err(|e| e.to_string())?;
     }
     Ok(())
+}
+
+// ── Import / Export types ─────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportResult {
+    pub added:   usize,
+    pub skipped: usize,
+    pub errors:  Vec<String>,
+}
+
+// ── Metadata fetch types ──────────────────────────────────────────────────────
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchedMetadata {
+    pub title:         Option<String>,
+    pub authors:       Option<String>,
+    pub year:          Option<String>,
+    pub journal:       Option<String>,
+    pub volume:        Option<String>,
+    pub issue:         Option<String>,
+    pub pages:         Option<String>,
+    pub doi:           Option<String>,
+    pub issn:          Option<String>,
+    pub publisher:     Option<String>,
+    pub url:           Option<String>,
+    pub abstract_text: Option<String>,
+    pub booktitle:     Option<String>,
+    pub isbn:          Option<String>,
+    pub entry_type:    Option<String>,
+}
+
+// ── Import / Export commands ──────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn import_bib_file(path: String, mode: String) -> Result<ImportResult, String> {
+    let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let entries = parse_bib(&content);
+    let conn = open_conn()?;
+
+    let replace = mode == "replace";
+    let mut added   = 0usize;
+    let mut skipped = 0usize;
+    let mut errors: Vec<String> = vec![];
+
+    let sql_merge   = "INSERT OR IGNORE INTO items
+         (key,entry_type,title,authors,year,journal,doi,abstract_text,url,
+          volume,issue,pages,publisher,booktitle,edition,month,keywords,
+          note,isbn,issn,number,institution)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)";
+    let sql_replace = "INSERT OR REPLACE INTO items
+         (key,entry_type,title,authors,year,journal,doi,abstract_text,url,
+          volume,issue,pages,publisher,booktitle,edition,month,keywords,
+          note,isbn,issn,number,institution)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)";
+    let sql = if replace { sql_replace } else { sql_merge };
+
+    for entry in &entries {
+        match conn.execute(sql, params![
+            entry.key, entry.entry_type, entry.title, entry.authors, entry.year,
+            entry.journal, entry.doi, entry.abstract_text, entry.url, entry.volume,
+            entry.issue, entry.pages, entry.publisher, entry.booktitle, entry.edition,
+            entry.month, entry.keywords, entry.note, entry.isbn, entry.issn,
+            entry.number, entry.institution
+        ]) {
+            Ok(rows) => { if rows > 0 { added += 1; } else { skipped += 1; } }
+            Err(e)   => { errors.push(format!("{}: {}", entry.key, e)); }
+        }
+    }
+
+    let _ = regenerate_bib(&conn);
+    Ok(ImportResult { added, skipped, errors })
+}
+
+#[tauri::command]
+pub fn export_bib_file(item_ids: Vec<i64>, path: String) -> Result<usize, String> {
+    let conn = open_conn()?;
+    let items: Vec<LibraryItem> = if item_ids.is_empty() {
+        let sql = format!(
+            "{} WHERE i.id NOT IN (SELECT item_id FROM trash) GROUP BY i.id ORDER BY i.added_at ASC",
+            ITEM_SELECT
+        );
+        let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+        let rows = stmt.query_map([], |row| row_to_item(row))
+            .map_err(|e| e.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+        rows
+    } else {
+        let placeholders: Vec<String> =
+            (1..=item_ids.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "{} WHERE i.id IN ({}) GROUP BY i.id ORDER BY i.added_at ASC",
+            ITEM_SELECT,
+            placeholders.join(",")
+        );
+        let binds: Vec<Value> = item_ids.iter().map(|&id| Value::Integer(id)).collect();
+        let refs: Vec<&dyn rusqlite::types::ToSql> =
+            binds.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
+        let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+        let rows = stmt.query_map(refs.as_slice(), |row| row_to_item(row))
+            .map_err(|e| e.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+        rows
+    };
+    let count = items.len();
+    fs::write(&path, items_to_bib(&items)).map_err(|e| e.to_string())?;
+    Ok(count)
+}
+
+// ── Metadata fetch helpers ────────────────────────────────────────────────────
+
+fn strip_xml_tags(s: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn xml_tag_text(xml: &str, tag: &str) -> Option<String> {
+    let open  = format!("<{}", tag);
+    let close = format!("</{}>", tag);
+    let start = xml.find(&open)?;
+    let after = &xml[start..];
+    let cs = after.find('>')? + 1;
+    let ce = after.find(&close)?;
+    if cs >= ce { return None; }
+    let text = strip_xml_tags(after[cs..ce].trim());
+    if text.is_empty() { None } else { Some(text) }
+}
+
+// ── DOI fetch via CrossRef ────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn fetch_doi_metadata(doi: String) -> Result<FetchedMetadata, String> {
+    let url = format!("https://api.crossref.org/works/{}", doi.trim());
+    let client = reqwest::Client::builder()
+        .user_agent("Quire/1.0 (https://github.com/quire)")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client.get(&url).send().await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("DOI not found (HTTP {})", resp.status().as_u16()));
+    }
+    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    let msg = &json["message"];
+
+    let title = msg["title"].as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let authors = msg["author"].as_array().map(|arr| {
+        arr.iter().filter_map(|a| {
+            let fam = a["family"].as_str()?;
+            let giv = a["given"].as_str().unwrap_or("");
+            Some(if giv.is_empty() { fam.to_string() } else { format!("{fam}, {giv}") })
+        })
+        .collect::<Vec<_>>()
+        .join(" and ")
+    }).filter(|s| !s.is_empty());
+
+    let year = msg["published"]["date-parts"]
+        .as_array().and_then(|a| a.first())
+        .and_then(|dp| dp.as_array()).and_then(|dp| dp.first())
+        .and_then(|y| y.as_u64()).map(|y| y.to_string());
+
+    let journal = msg["container-title"].as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let volume    = msg["volume"].as_str().map(String::from);
+    let issue     = msg["issue"].as_str().map(String::from);
+    let pages     = msg["page"].as_str().map(String::from);
+    let doi_val   = msg["DOI"].as_str().map(String::from)
+        .unwrap_or_else(|| doi.trim().to_string());
+    let issn      = msg["ISSN"].as_array()
+        .and_then(|a| a.first()).and_then(|v| v.as_str()).map(String::from);
+    let publisher = msg["publisher"].as_str().map(String::from);
+    let url_val   = msg["URL"].as_str().map(String::from);
+    let abstract_text = msg["abstract"].as_str()
+        .map(|s| strip_xml_tags(s)).filter(|s| !s.is_empty());
+
+    Ok(FetchedMetadata {
+        title, authors, year, journal, volume, issue, pages,
+        doi: Some(doi_val), issn, publisher, url: url_val, abstract_text,
+        entry_type: Some("article".to_string()),
+        ..Default::default()
+    })
+}
+
+// ── arXiv fetch ───────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn fetch_arxiv_metadata(arxiv_id: String) -> Result<FetchedMetadata, String> {
+    let raw = arxiv_id.trim()
+        .trim_start_matches("arXiv:")
+        .trim_start_matches("arxiv:");
+    let clean = raw.split('v').next().unwrap_or(raw).trim();
+
+    let url = format!("https://export.arxiv.org/api/query?id_list={clean}");
+    let xml = reqwest::get(&url).await
+        .map_err(|e| format!("Network error: {e}"))?
+        .text().await.map_err(|e| e.to_string())?;
+
+    if xml.contains("<opensearch:totalResults>0</opensearch:totalResults>") {
+        return Err("arXiv ID not found".to_string());
+    }
+
+    let title   = xml_tag_text(&xml, "title").filter(|s| !s.contains("ArXiv Query"));
+    let summary = xml_tag_text(&xml, "summary");
+    let year    = xml_tag_text(&xml, "published").and_then(|d| d.get(..4).map(String::from));
+    let doi     = xml_tag_text(&xml, "arxiv:doi");
+    let journal = xml_tag_text(&xml, "arxiv:journal_ref");
+    let url_val = xml_tag_text(&xml, "id").filter(|s| s.contains("arxiv.org"));
+
+    // Collect all <author> blocks
+    let authors = {
+        let mut names = Vec::new();
+        let mut pos = 0usize;
+        while let Some(rel) = xml[pos..].find("<author>") {
+            let s = pos + rel;
+            let e = xml[s..].find("</author>").map(|x| s + x + 9).unwrap_or(s + 8);
+            if let Some(name) = xml_tag_text(&xml[s..e], "name") {
+                names.push(name);
+            }
+            pos = e;
+        }
+        if names.is_empty() { None } else { Some(names.join(" and ")) }
+    };
+
+    Ok(FetchedMetadata {
+        title, authors, year, journal, doi, url: url_val,
+        abstract_text: summary,
+        entry_type: Some("misc".to_string()),
+        ..Default::default()
+    })
+}
+
+// ── ISBN fetch via OpenLibrary ────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn fetch_isbn_metadata(isbn: String) -> Result<FetchedMetadata, String> {
+    let clean: String = isbn.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    let url = format!(
+        "https://openlibrary.org/api/books?bibkeys=ISBN:{clean}&format=json&jscmd=data"
+    );
+    let json: serde_json::Value = reqwest::get(&url).await
+        .map_err(|e| format!("Network error: {e}"))?
+        .json().await.map_err(|e| e.to_string())?;
+
+    let key  = format!("ISBN:{clean}");
+    let book = json.get(&key).ok_or("ISBN not found in OpenLibrary")?;
+
+    let title = book["title"].as_str().map(String::from);
+
+    let authors = book["authors"].as_array().map(|arr| {
+        arr.iter().filter_map(|a| a["name"].as_str()).collect::<Vec<_>>().join(" and ")
+    }).filter(|s| !s.is_empty());
+
+    // publish_date can be "April 2004", "2004", "2004-03-01"
+    let year = book["publish_date"].as_str().and_then(|d| {
+        d.split(|c: char| !c.is_ascii_digit()).find(|p| p.len() == 4).map(String::from)
+    });
+
+    let publisher = book["publishers"].as_array()
+        .and_then(|a| a.first())
+        .and_then(|p| p["name"].as_str())
+        .map(String::from);
+
+    Ok(FetchedMetadata {
+        title, authors, year, publisher, isbn: Some(clean),
+        entry_type: Some("book".to_string()),
+        ..Default::default()
+    })
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "ire",
+        "title": "Quire",
         "width": 800,
         "height": 600
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,7 +29,7 @@ function handleNewDoc() {
   // Reset document state — WriteView listens for doc:opened with empty content
   const doc = useDocument()
   doc.docTitle.value = 'Untitled Document'
-  doc.docAuthors.value = ['[Author]']
+  doc.docAuthors.value = [{ name: '[Author]', orcid: '', title: '', affiliation: '' }]
   doc.filePath.value = null
   doc.isDirty.value = false
   emitter.emit('doc:opened', {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { invoke } from '@tauri-apps/api/core'
 import TitleBar from './components/TitleBar.vue'
 import Sidebar from './components/Sidebar.vue'
 import StatusBar from './components/StatusBar.vue'
 import { useDocument } from './composables/useDocument'
+import { emitter } from './events'
 
 const route = useRoute()
-const { docTitle, isDirty } = useDocument()
+const { docTitle, filePath, isDirty } = useDocument()
+
+async function handleExport() {
+  if (!filePath.value) return
+  const format = route.name === 'pdf' ? 'pdf' : 'pdf'
+  emitter.emit('export:start')
+  try {
+    const result = await invoke<string>('run_quarto', { docPath: filePath.value, format })
+    const outputPath = result.split('Output: ')[1]?.trim() ?? ''
+    emitter.emit('export:done', { outputPath })
+  } catch (e) {
+    emitter.emit('export:error', { message: String(e) })
+  }
+}
 
 const titleConfig = computed(() => {
   switch (route.name) {
@@ -42,6 +57,7 @@ const titleConfig = computed(() => {
       :subtitle="titleConfig.subtitle"
       :export-label="titleConfig.exportLabel"
       :is-dirty="isDirty"
+      :on-export="handleExport"
     />
     <div class="app-body">
       <Sidebar />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,22 +1,69 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
 import TitleBar from './components/TitleBar.vue'
 import Sidebar from './components/Sidebar.vue'
 import StatusBar from './components/StatusBar.vue'
+import HamburgerMenu from './components/HamburgerMenu.vue'
 import { useDocument } from './composables/useDocument'
+import { useQuire } from './composables/useQuire'
+import { useFileOps } from './composables/useFileOps'
 import { emitter } from './events'
 
 const route = useRoute()
+const router = useRouter()
 const { docTitle, filePath, isDirty } = useDocument()
+const { initQuire, addRecentFile } = useQuire()
+useFileOps()
+
+// ── Menu ──────────────────────────────────────────────────────────────────────
+
+const menuOpen = ref(false)
+
+function toggleMenu() {
+  menuOpen.value = !menuOpen.value
+}
+
+function handleNewDoc() {
+  // Reset document state — WriteView listens for doc:opened with empty content
+  const doc = useDocument()
+  doc.docTitle.value = 'Untitled Document'
+  doc.docAuthors.value = ['[Author]']
+  doc.filePath.value = null
+  doc.isDirty.value = false
+  emitter.emit('doc:opened', {
+    path: '',
+    content: `<h2>Abstract</h2><p></p><h2>1. Introduction</h2><p></p>`,
+  })
+  router.push('/write')
+}
+
+// ── Title config ──────────────────────────────────────────────────────────────
+
+const titleConfig = computed(() => {
+  switch (route.name) {
+    case 'write':
+      return { title: docTitle.value, subtitle: 'Write', exportLabel: 'Export as PDF' }
+    case 'workbench':
+      return { title: 'Workbench', subtitle: docTitle.value, exportLabel: null }
+    case 'pdf':
+      return { title: 'Popova et al. 2022', subtitle: 'PDF Viewer', exportLabel: 'Export as .bib' }
+    default:
+      return { title: 'Quire', subtitle: '', exportLabel: null }
+  }
+})
+
+// ── Export ────────────────────────────────────────────────────────────────────
 
 async function handleExport() {
   if (!filePath.value) return
-  const format = route.name === 'pdf' ? 'pdf' : 'pdf'
   emitter.emit('export:start')
   try {
-    const result = await invoke<string>('run_quarto', { docPath: filePath.value, format })
+    const result = await invoke<string>('run_quarto', {
+      docPath: filePath.value,
+      format: 'pdf',
+    })
     const outputPath = result.split('Output: ')[1]?.trim() ?? ''
     emitter.emit('export:done', { outputPath })
   } catch (e) {
@@ -24,29 +71,39 @@ async function handleExport() {
   }
 }
 
-const titleConfig = computed(() => {
-  switch (route.name) {
-    case 'write':
-      return {
-        title: docTitle.value,
-        subtitle: 'Write',
-        exportLabel: 'Export as PDF',
-      }
-    case 'workbench':
-      return {
-        title: 'Workbench',
-        subtitle: docTitle.value,
-        exportLabel: null,
-      }
-    case 'pdf':
-      return {
-        title: 'Popova et al. 2022',
-        subtitle: 'PDF Viewer',
-        exportLabel: 'Export as .bib',
-      }
-    default:
-      return { title: 'Quire', subtitle: '', exportLabel: null }
+// ── Keyboard shortcuts (app-level) ────────────────────────────────────────────
+
+function onKeydown(e: KeyboardEvent) {
+  const ctrl = e.ctrlKey || e.metaKey
+  if (ctrl && e.key === 'n') {
+    e.preventDefault()
+    handleNewDoc()
   }
+  if (e.key === 'Escape' && menuOpen.value) {
+    menuOpen.value = false
+  }
+}
+
+// ── Recent files tracking ─────────────────────────────────────────────────────
+
+emitter.on('doc:saved', ({ path }) => {
+  addRecentFile(path, docTitle.value)
+})
+emitter.on('doc:opened', ({ path }) => {
+  if (path) addRecentFile(path, docTitle.value)
+})
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+onMounted(async () => {
+  await initQuire()
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  emitter.off('doc:saved')
+  emitter.off('doc:opened')
 })
 </script>
 
@@ -58,7 +115,15 @@ const titleConfig = computed(() => {
       :export-label="titleConfig.exportLabel"
       :is-dirty="isDirty"
       :on-export="handleExport"
+      @toggle-menu="toggleMenu"
     />
+
+    <HamburgerMenu
+      v-if="menuOpen"
+      @close="menuOpen = false"
+      @new-doc="handleNewDoc"
+    />
+
     <div class="app-body">
       <Sidebar />
       <main class="main-content">

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,19 +4,33 @@ import { useRoute } from 'vue-router'
 import TitleBar from './components/TitleBar.vue'
 import Sidebar from './components/Sidebar.vue'
 import StatusBar from './components/StatusBar.vue'
+import { useDocument } from './composables/useDocument'
 
 const route = useRoute()
+const { docTitle, isDirty } = useDocument()
 
 const titleConfig = computed(() => {
   switch (route.name) {
     case 'write':
-      return { title: 'Allergen Labelling Study', subtitle: 'Write', exportLabel: 'Export as PDF' }
+      return {
+        title: docTitle.value,
+        subtitle: 'Write',
+        exportLabel: 'Export as PDF',
+      }
     case 'workbench':
-      return { title: 'Workbench', subtitle: 'Allergen Labelling Study', exportLabel: null }
+      return {
+        title: 'Workbench',
+        subtitle: docTitle.value,
+        exportLabel: null,
+      }
     case 'pdf':
-      return { title: 'Popova et al. 2022', subtitle: 'PDF Viewer', exportLabel: 'Export as .bib' }
+      return {
+        title: 'Popova et al. 2022',
+        subtitle: 'PDF Viewer',
+        exportLabel: 'Export as .bib',
+      }
     default:
-      return { title: 'IRE', subtitle: '', exportLabel: null }
+      return { title: 'Quire', subtitle: '', exportLabel: null }
   }
 })
 </script>
@@ -27,6 +41,7 @@ const titleConfig = computed(() => {
       :title="titleConfig.title"
       :subtitle="titleConfig.subtitle"
       :export-label="titleConfig.exportLabel"
+      :is-dirty="isDirty"
     />
     <div class="app-body">
       <Sidebar />

--- a/src/assets/editor.css
+++ b/src/assets/editor.css
@@ -1,4 +1,4 @@
-/* Tiptap editor — mirrors exact placeholder paper styles */
+/* Tiptap editor styles */
 
 .ProseMirror {
   outline: none;
@@ -7,26 +7,80 @@
   line-height: 1.8;
   color: var(--text);
   min-height: 200px;
+  counter-reset: section subsection subsubsection;
 }
 
 .ProseMirror > * + * {
   margin-top: 0;
 }
 
-.ProseMirror h2 {
+/* ── Heading hierarchy (all-caps labels + auto-number) ─────── */
+
+.ProseMirror h1 {
   font-family: var(--font-ui);
-  font-size: 10.5px;
+  font-size: 13px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.09em;
-  color: var(--text-tertiary);
-  margin-bottom: 10px;
-  margin-top: 28px;
+  letter-spacing: 0.07em;
+  color: var(--text);
+  margin-top: 36px;
+  margin-bottom: 12px;
+  counter-increment: section;
+  counter-reset: subsection subsubsection;
 }
 
-.ProseMirror h2:first-child {
+.ProseMirror h1:first-child {
   margin-top: 0;
 }
+
+.ProseMirror h1::before {
+  content: counter(section) " · ";
+  color: var(--text-tertiary);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.ProseMirror h2 {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text);
+  margin-top: 24px;
+  margin-bottom: 8px;
+  counter-increment: subsection;
+  counter-reset: subsubsection;
+}
+
+.ProseMirror h2::before {
+  content: counter(section) "." counter(subsection) " · ";
+  color: var(--text-tertiary);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.ProseMirror h3 {
+  font-family: var(--font-doc);
+  font-size: 16px;
+  font-weight: 600;
+  font-style: italic;
+  color: var(--text);
+  margin-top: 18px;
+  margin-bottom: 6px;
+  counter-increment: subsubsection;
+}
+
+.ProseMirror h3::before {
+  content: counter(section) "." counter(subsection) "." counter(subsubsection) "  ";
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 400;
+  font-style: normal;
+  font-family: var(--font-ui);
+}
+
+/* ── Body text ─────────────────────────────────────────────── */
 
 .ProseMirror p {
   font-family: var(--font-doc);
@@ -49,7 +103,8 @@
   font-style: italic;
 }
 
-/* Citation inline node */
+/* ── Citation inline node ──────────────────────────────────── */
+
 .cite-inline-node {
   display: inline;
 }
@@ -57,15 +112,13 @@
 .cite-sup-node {
   color: var(--accent);
   font-family: var(--font-ui);
-  font-size: 9.5px;
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
   letter-spacing: -0.01em;
-  padding: 0 1.5px;
+  padding: 0 1px;
   border-radius: 2px;
   cursor: pointer;
   transition: background var(--t);
-  vertical-align: super;
-  line-height: 0;
   user-select: none;
   -webkit-user-select: none;
 }
@@ -82,10 +135,134 @@
   background: rgba(196, 80, 0, 0.08);
 }
 
-/* Tiptap selection */
 .ProseMirror .ProseMirror-selectednode .cite-sup-node {
   background: var(--accent-soft);
   outline: 2px solid var(--accent);
   outline-offset: 1px;
   border-radius: 2px;
+}
+
+/* ── Section cross-references ──────────────────────────────── */
+
+.section-ref-inline {
+  display: inline;
+}
+
+.section-ref-node {
+  color: var(--accent-purple, #7C3AED);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 2px;
+  padding: 0 2px;
+  transition: background var(--t);
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.section-ref-node:hover {
+  background: rgba(124, 58, 237, 0.09);
+}
+
+.section-ref-unresolved {
+  color: var(--accent-orange, #E8650A);
+}
+
+/* ── Find & Replace highlights ─────────────────────────────── */
+
+.search-match {
+  background: rgba(255, 200, 0, 0.35);
+  border-radius: 2px;
+}
+
+.search-current {
+  background: rgba(255, 140, 0, 0.55);
+  border-radius: 2px;
+  outline: 1px solid rgba(200, 100, 0, 0.5);
+  outline-offset: 1px;
+}
+
+/* ── Math (KaTeX) ──────────────────────────────────────────── */
+
+.ProseMirror .katex {
+  font-size: 1.05em;
+}
+
+.ProseMirror .tiptap-mathematics-render {
+  display: block;
+  margin: 20px 0;
+  text-align: center;
+  overflow-x: auto;
+  border-radius: 4px;
+  padding: 2px 0;
+  transition: background var(--t);
+}
+
+.ProseMirror .tiptap-mathematics-render--editable {
+  cursor: pointer;
+}
+
+.ProseMirror .tiptap-mathematics-render--editable:hover {
+  background: var(--accent-soft);
+}
+
+/* inline math wrapper */
+.ProseMirror span[data-type="inlineMath"] .tiptap-mathematics-render {
+  display: inline;
+  margin: 0;
+  padding: 0 1px;
+}
+
+/* ── Math edit overlay ─────────────────────────────────────── */
+
+.math-edit-overlay {
+  position: fixed;
+  z-index: 9998;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+  padding: 12px 14px 10px;
+  width: 340px;
+}
+
+.math-edit-label {
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.math-edit-input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-mono, "JetBrains Mono", "Fira Code", "Courier New", monospace);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg-chrome, #F0EFEC);
+  border: 1px solid var(--border, rgba(0,0,0,0.1));
+  border-radius: 6px;
+  padding: 8px 10px;
+  resize: vertical;
+  outline: none;
+  transition: border-color var(--t);
+}
+
+.math-edit-input:focus {
+  border-color: var(--accent);
+}
+
+.math-edit-hint {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  color: var(--text-secondary);
+  margin-top: 6px;
+  text-align: right;
 }

--- a/src/assets/editor.css
+++ b/src/assets/editor.css
@@ -149,7 +149,7 @@
 }
 
 .focus-mode .ProseMirror > .doc-above {
-  opacity: 0.28;
+  opacity: 0.22;
 }
 
 /* ── Section cross-references ──────────────────────────────── */

--- a/src/assets/editor.css
+++ b/src/assets/editor.css
@@ -142,6 +142,16 @@
   border-radius: 2px;
 }
 
+/* ── Focus mode ────────────────────────────────────────────── */
+
+.ProseMirror > * {
+  transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.focus-mode .ProseMirror > .doc-above {
+  opacity: 0.28;
+}
+
 /* ── Section cross-references ──────────────────────────────── */
 
 .section-ref-inline {

--- a/src/assets/editor.css
+++ b/src/assets/editor.css
@@ -1,0 +1,83 @@
+/* Tiptap editor — mirrors exact placeholder paper styles */
+
+.ProseMirror {
+  outline: none;
+  font-family: var(--font-doc);
+  font-size: 15.5px;
+  line-height: 1.8;
+  color: var(--text);
+  min-height: 200px;
+}
+
+.ProseMirror > * + * {
+  margin-top: 0;
+}
+
+.ProseMirror h2 {
+  font-family: var(--font-ui);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-tertiary);
+  margin-bottom: 10px;
+  margin-top: 28px;
+}
+
+.ProseMirror h2:first-child {
+  margin-top: 0;
+}
+
+.ProseMirror p {
+  font-family: var(--font-doc);
+  font-size: 15.5px;
+  line-height: 1.8;
+  color: var(--text);
+  margin-bottom: 14px;
+}
+
+.ProseMirror p:last-child {
+  margin-bottom: 0;
+}
+
+.ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: var(--text-tertiary);
+  pointer-events: none;
+  float: left;
+  height: 0;
+  font-style: italic;
+}
+
+/* Citation inline node */
+.cite-inline-node {
+  display: inline;
+}
+
+.cite-sup-node {
+  color: var(--accent);
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  padding: 0 1.5px;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background var(--t);
+  vertical-align: super;
+  line-height: 0;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.cite-sup-node:hover {
+  background: var(--accent-soft);
+}
+
+/* Tiptap selection */
+.ProseMirror .ProseMirror-selectednode .cite-sup-node {
+  background: var(--accent-soft);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 2px;
+}

--- a/src/assets/editor.css
+++ b/src/assets/editor.css
@@ -74,6 +74,14 @@
   background: var(--accent-soft);
 }
 
+.cite-sup-unresolved {
+  color: var(--accent-orange, #C45000);
+}
+
+.cite-sup-unresolved:hover {
+  background: rgba(196, 80, 0, 0.08);
+}
+
 /* Tiptap selection */
 .ProseMirror .ProseMirror-selectednode .cite-sup-node {
   background: var(--accent-soft);

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -14,8 +14,8 @@
   --border: rgba(0, 0, 0, 0.07);
   --border-medium: rgba(0, 0, 0, 0.12);
   --text: #1A1917;
-  --text-secondary: #6B6A68;
-  --text-tertiary: #A5A4A2;
+  --text-secondary: #3D3C3A;
+  --text-tertiary: #6B6A68;
   --accent: #0A5FBF;
   --accent-soft: rgba(10, 95, 191, 0.08);
   --accent-orange: #E8650A;

--- a/src/components/CitationNodeView.vue
+++ b/src/components/CitationNodeView.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3'
 import { emitter } from '../events'
+import { useDocument } from '../composables/useDocument'
 
 const props = defineProps(nodeViewProps)
+const { citations } = useDocument()
+
+const resolved = computed(() =>
+  citations.value.some(c => c.key === props.node.attrs.citeKey)
+)
 
 function onMouseEnter(e: MouseEvent) {
   const el = e.currentTarget as HTMLElement
@@ -22,10 +29,11 @@ function onClick() {
 <template>
   <NodeViewWrapper as="span" class="cite-inline-node">
     <sup
-      class="cite-sup-node"
+      :class="['cite-sup-node', { 'cite-sup-unresolved': !resolved }]"
+      :title="!resolved ? `No entry for '${node.attrs.citeKey}' in references.bib` : undefined"
       @mouseenter="onMouseEnter"
       @mouseleave="onMouseLeave"
       @click.stop="onClick"
-    >[{{ node.attrs.displayIndex }}]</sup>
+    >{{ resolved ? `[${node.attrs.displayIndex}]` : '[?]' }}</sup>
   </NodeViewWrapper>
 </template>

--- a/src/components/CitationNodeView.vue
+++ b/src/components/CitationNodeView.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3'
+import { emitter } from '../events'
+
+const props = defineProps(nodeViewProps)
+
+function onMouseEnter(e: MouseEvent) {
+  const el = e.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  emitter.emit('cite:hover', { key: props.node.attrs.citeKey, rect })
+}
+
+function onMouseLeave() {
+  emitter.emit('cite:leave')
+}
+
+function onClick() {
+  emitter.emit('cite:click', { key: props.node.attrs.citeKey })
+}
+</script>
+
+<template>
+  <NodeViewWrapper as="span" class="cite-inline-node">
+    <sup
+      class="cite-sup-node"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+      @click.stop="onClick"
+    >[{{ node.attrs.displayIndex }}]</sup>
+  </NodeViewWrapper>
+</template>

--- a/src/components/CitationNodeView.vue
+++ b/src/components/CitationNodeView.vue
@@ -28,12 +28,12 @@ function onClick() {
 
 <template>
   <NodeViewWrapper as="span" class="cite-inline-node">
-    <sup
+    <span
       :class="['cite-sup-node', { 'cite-sup-unresolved': !resolved }]"
       :title="!resolved ? `No entry for '${node.attrs.citeKey}' in references.bib` : undefined"
       @mouseenter="onMouseEnter"
       @mouseleave="onMouseLeave"
       @click.stop="onClick"
-    >{{ resolved ? `[${node.attrs.displayIndex}]` : '[?]' }}</sup>
+    >{{ resolved ? `[${node.attrs.displayIndex}]` : '[?]' }}</span>
   </NodeViewWrapper>
 </template>

--- a/src/components/CitationSuggestList.vue
+++ b/src/components/CitationSuggestList.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { BibEntry } from '../composables/useDocument'
+
+const props = defineProps<{
+  items: BibEntry[]
+  command: (item: BibEntry) => void
+}>()
+
+const selectedIndex = ref(0)
+
+watch(
+  () => props.items,
+  () => { selectedIndex.value = 0 },
+)
+
+function select(item: BibEntry) {
+  props.command(item)
+}
+
+function onKeyDown(event: KeyboardEvent): boolean {
+  if (event.key === 'ArrowUp') {
+    selectedIndex.value =
+      (selectedIndex.value - 1 + props.items.length) % props.items.length
+    return true
+  }
+  if (event.key === 'ArrowDown') {
+    selectedIndex.value = (selectedIndex.value + 1) % props.items.length
+    return true
+  }
+  if (event.key === 'Enter') {
+    const item = props.items[selectedIndex.value]
+    if (item) select(item)
+    return true
+  }
+  return false
+}
+
+defineExpose({ onKeyDown })
+</script>
+
+<template>
+  <div class="cite-suggest" v-if="items.length">
+    <div class="suggest-header">Cite from bibliography</div>
+    <button
+      v-for="(item, i) in items"
+      :key="item.key"
+      class="suggest-item"
+      :class="{ 'suggest-item--active': i === selectedIndex }"
+      @mouseenter="selectedIndex = i"
+      @mousedown.prevent="select(item)"
+    >
+      <span class="suggest-key">{{ item.key }}</span>
+      <span class="suggest-body">
+        <span class="suggest-title">{{ item.title }}</span>
+        <span class="suggest-meta">{{ item.authors }}{{ item.year ? ' · ' + item.year : '' }}</span>
+      </span>
+    </button>
+  </div>
+  <div class="cite-suggest cite-suggest--empty" v-else>
+    No matches in references.bib
+  </div>
+</template>
+
+<style scoped>
+.cite-suggest {
+  background: rgba(252, 251, 249, 0.98);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.07);
+  min-width: 340px;
+  max-width: 400px;
+  overflow: hidden;
+  animation: suggestIn 0.14s cubic-bezier(0.34, 1.2, 0.64, 1);
+  transform-origin: top left;
+}
+
+@keyframes suggestIn {
+  from { opacity: 0; transform: scale(0.96) translateY(-4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.cite-suggest--empty {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #8E8E93;
+  font-style: italic;
+}
+
+.suggest-header {
+  padding: 7px 12px 5px;
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: #8E8E93;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+}
+
+.suggest-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.suggest-item--active {
+  background: rgba(10, 95, 191, 0.08);
+}
+
+.suggest-key {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 10px;
+  color: #0A5FBF;
+  background: rgba(10, 95, 191, 0.08);
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.suggest-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow: hidden;
+}
+
+.suggest-title {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: #1A1917;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.suggest-meta {
+  font-size: 10.5px;
+  color: #8E8E93;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+</style>

--- a/src/components/CollectionsSidebar.vue
+++ b/src/components/CollectionsSidebar.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+import { ref, computed, nextTick } from 'vue'
+import { useLibrary } from '../composables/useLibrary'
+
+const {
+  items, collections, tags, filterQuery, applyFilter,
+  createCollection, renameCollection, deleteCollection,
+} = useLibrary()
+
+const isAllItems = computed(() =>
+  !filterQuery.value.collectionId && !filterQuery.value.tagName
+)
+
+function selectAll() {
+  filterQuery.value = { ...filterQuery.value, collectionId: null, tagName: null }
+  applyFilter()
+}
+
+function selectCollection(id: number) {
+  filterQuery.value = { ...filterQuery.value, collectionId: id, tagName: null }
+  applyFilter()
+}
+
+function selectTag(name: string) {
+  const already = filterQuery.value.tagName === name
+  filterQuery.value = { ...filterQuery.value, tagName: already ? null : name, collectionId: null }
+  applyFilter()
+}
+
+// ── New collection ─────────────────────────────────────────────────────────────
+
+const creatingNew = ref(false)
+const newName = ref('')
+const newInput = ref<HTMLInputElement | null>(null)
+
+async function startNew() {
+  creatingNew.value = true
+  newName.value = ''
+  await nextTick()
+  newInput.value?.focus()
+}
+
+async function confirmNew() {
+  const name = newName.value.trim()
+  if (name) await createCollection(name)
+  creatingNew.value = false
+  newName.value = ''
+}
+
+function onNewKey(e: KeyboardEvent) {
+  if (e.key === 'Enter') confirmNew()
+  if (e.key === 'Escape') { creatingNew.value = false; newName.value = '' }
+}
+
+// ── Rename ─────────────────────────────────────────────────────────────────────
+
+const renamingId = ref<number | null>(null)
+const renameValue = ref('')
+const renameInput = ref<HTMLInputElement | null>(null)
+
+async function startRename(id: number, current: string, e: Event) {
+  e.stopPropagation()
+  renamingId.value = id
+  renameValue.value = current
+  await nextTick()
+  renameInput.value?.focus()
+  renameInput.value?.select()
+}
+
+async function confirmRename(id: number) {
+  const name = renameValue.value.trim()
+  if (name) await renameCollection(id, name)
+  renamingId.value = null
+}
+
+function onRenameKey(e: KeyboardEvent, id: number) {
+  if (e.key === 'Enter') confirmRename(id)
+  if (e.key === 'Escape') renamingId.value = null
+}
+
+// ── Delete ─────────────────────────────────────────────────────────────────────
+
+async function doDelete(id: number, e: Event) {
+  e.stopPropagation()
+  await deleteCollection(id)
+}
+</script>
+
+<template>
+  <aside class="coll-sidebar">
+    <!-- All Items -->
+    <div
+      class="coll-row coll-all"
+      :class="{ active: isAllItems }"
+      @click="selectAll"
+    >
+      <svg class="coll-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="1" y1="3" x2="11" y2="3"/>
+        <line x1="1" y1="6" x2="11" y2="6"/>
+        <line x1="1" y1="9" x2="11" y2="9"/>
+      </svg>
+      <span class="coll-name">All Items</span>
+      <span class="coll-count">{{ items.length }}</span>
+    </div>
+
+    <!-- Collections -->
+    <div class="coll-section">
+      <div class="coll-section-head">
+        <span class="coll-section-label">Collections</span>
+        <button class="coll-icon-btn" @click="startNew" title="New collection">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="5" y1="1" x2="5" y2="9"/>
+            <line x1="1" y1="5" x2="9" y2="5"/>
+          </svg>
+        </button>
+      </div>
+
+      <div
+        v-for="col in collections"
+        :key="col.id"
+        class="coll-row"
+        :class="{ active: filterQuery.collectionId === col.id }"
+        @click="selectCollection(col.id)"
+        @dblclick="startRename(col.id, col.name, $event)"
+      >
+        <svg class="coll-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 3.5C1 2.67 1.67 2 2.5 2h2L5.5 3.5h4c.83 0 1.5.67 1.5 1.5v4c0 .83-.67 1.5-1.5 1.5h-7C1.67 10.5 1 9.83 1 9V3.5Z"/>
+        </svg>
+
+        <template v-if="renamingId === col.id">
+          <input
+            ref="renameInput"
+            v-model="renameValue"
+            class="coll-inline-input"
+            @blur="confirmRename(col.id)"
+            @keydown="onRenameKey($event, col.id)"
+            @click.stop
+          />
+        </template>
+        <template v-else>
+          <span class="coll-name">{{ col.name }}</span>
+          <span class="coll-count">{{ col.itemCount }}</span>
+          <button
+            class="coll-del-btn"
+            @click="doDelete(col.id, $event)"
+            title="Delete collection"
+          >
+            <svg width="9" height="9" viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <line x1="1" y1="1" x2="8" y2="8"/>
+              <line x1="8" y1="1" x2="1" y2="8"/>
+            </svg>
+          </button>
+        </template>
+      </div>
+
+      <!-- New collection input row -->
+      <div class="coll-row coll-new-row" v-if="creatingNew">
+        <svg class="coll-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 3.5C1 2.67 1.67 2 2.5 2h2L5.5 3.5h4c.83 0 1.5.67 1.5 1.5v4c0 .83-.67 1.5-1.5 1.5h-7C1.67 10.5 1 9.83 1 9V3.5Z"/>
+        </svg>
+        <input
+          ref="newInput"
+          v-model="newName"
+          class="coll-inline-input"
+          placeholder="Collection name"
+          @blur="confirmNew"
+          @keydown="onNewKey"
+        />
+      </div>
+
+      <div class="coll-empty-hint" v-if="collections.length === 0 && !creatingNew">
+        No collections yet
+      </div>
+    </div>
+
+    <!-- Tags -->
+    <div class="coll-section" v-if="tags.length > 0">
+      <div class="coll-section-head">
+        <span class="coll-section-label">Tags</span>
+      </div>
+      <div
+        v-for="tag in tags"
+        :key="tag.id"
+        class="coll-row coll-tag-row"
+        :class="{ active: filterQuery.tagName === tag.name }"
+        @click="selectTag(tag.name)"
+      >
+        <span class="tag-dot" :style="{ background: tag.color }"></span>
+        <span class="coll-name">{{ tag.name }}</span>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.coll-sidebar {
+  width: 180px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-chrome);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding-bottom: 16px;
+}
+
+.coll-section {
+  margin-top: 6px;
+}
+
+.coll-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px 3px 14px;
+}
+
+.coll-section-label {
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-tertiary);
+}
+
+.coll-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-xs);
+  transition: background var(--t), color var(--t);
+}
+.coll-icon-btn:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+.coll-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px 5px 12px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  margin: 0 4px;
+  min-height: 27px;
+  position: relative;
+  transition: background var(--t);
+}
+
+.coll-row:hover {
+  background: var(--bg-chrome-active);
+}
+
+.coll-row.active {
+  background: var(--accent-soft);
+}
+
+.coll-row:hover .coll-del-btn {
+  opacity: 1;
+}
+
+.coll-all {
+  margin-top: 8px;
+}
+
+.coll-icon {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+
+.coll-name {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.coll-row.active .coll-name {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.coll-count {
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.coll-del-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-xs);
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--t), background var(--t), color var(--t);
+}
+.coll-del-btn:hover {
+  background: rgba(192, 57, 43, 0.1);
+  color: #C0392B;
+}
+
+.coll-inline-input {
+  flex: 1;
+  height: 22px;
+  padding: 0 6px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-xs);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface-solid);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+  min-width: 0;
+}
+
+.coll-empty-hint {
+  padding: 4px 14px 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.coll-tag-row {
+  padding-left: 12px;
+}
+
+.tag-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -1,0 +1,353 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+import { useQuire, type RecentFile } from '../composables/useQuire'
+import { useFileOps } from '../composables/useFileOps'
+
+const emit = defineEmits<{
+  close: []
+  newDoc: []
+}>()
+
+const router = useRouter()
+const { getRecentFiles, relativeTime } = useQuire()
+const { openDocument } = useFileOps()
+
+const recentFiles = ref<RecentFile[]>([])
+
+onMounted(async () => {
+  recentFiles.value = await getRecentFiles()
+  window.addEventListener('keydown', onKey)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKey)
+})
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+
+function shortPath(fullPath: string): string {
+  const home = fullPath.replace(/\\/g, '/').replace(/^C:\/Users\/[^/]+/, '~')
+  // Keep last 2 segments for readability
+  const parts = home.split('/')
+  if (parts.length > 3) return '…/' + parts.slice(-2).join('/')
+  return home
+}
+
+async function handleNew() {
+  emit('newDoc')
+  emit('close')
+}
+
+async function handleOpen() {
+  emit('close')
+  await openDocument()
+}
+
+async function handleRecent(file: RecentFile) {
+  emit('close')
+  try {
+    const { invoke } = await import('@tauri-apps/api/core')
+    const { useDocument } = await import('../composables/useDocument')
+    const doc = useDocument()
+    const result = await invoke<{ path: string; body: string; frontmatter: { title?: string; authors?: string[] } }>(
+      'open_document_path',
+      { path: file.path }
+    )
+    if (result.frontmatter.title) doc.docTitle.value = result.frontmatter.title
+    if (result.frontmatter.authors?.length) doc.docAuthors.value = result.frontmatter.authors
+    doc.filePath.value = result.path
+    doc.isDirty.value = false
+    // Emit the content via events so WriteView can pick it up
+    const { emitter } = await import('../events')
+    emitter.emit('doc:opened', { path: result.path, content: result.body })
+  } catch (e) {
+    console.error('Failed to open recent file:', e)
+  }
+  router.push('/write')
+}
+</script>
+
+<template>
+  <!-- Backdrop -->
+  <div class="menu-backdrop" @click="emit('close')"></div>
+
+  <!-- Panel -->
+  <div class="menu-panel">
+    <div class="menu-header">
+      <span class="menu-logo">Quire</span>
+      <button class="menu-close" @click="emit('close')">
+        <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+          <line x1="1" y1="1" x2="12" y2="12"/>
+          <line x1="12" y1="1" x2="1" y2="12"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Actions -->
+    <div class="menu-actions">
+      <button class="action-btn" @click="handleNew">
+        <span class="action-icon">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="11" height="11" rx="2"/>
+            <line x1="7.5" y1="5" x2="7.5" y2="10"/>
+            <line x1="5" y1="7.5" x2="10" y2="7.5"/>
+          </svg>
+        </span>
+        <span class="action-label">New Document</span>
+        <span class="action-hint">Ctrl N</span>
+      </button>
+      <button class="action-btn" @click="handleOpen">
+        <span class="action-icon">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M2 5h4l1.5-2H13v9H2V5Z"/>
+          </svg>
+        </span>
+        <span class="action-label">Open File…</span>
+        <span class="action-hint">Ctrl O</span>
+      </button>
+    </div>
+
+    <!-- Recent files -->
+    <div class="recent-section">
+      <div class="recent-label">Recent</div>
+      <div class="recent-list" v-if="recentFiles.length">
+        <button
+          v-for="file in recentFiles"
+          :key="file.path"
+          class="recent-item"
+          @click="handleRecent(file)"
+        >
+          <span class="recent-icon">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 1H3a1 1 0 00-1 1v9a1 1 0 001 1h7a1 1 0 001-1V5L8 1Z"/>
+              <path d="M8 1v4h4"/>
+            </svg>
+          </span>
+          <span class="recent-body">
+            <span class="recent-title">{{ file.title }}</span>
+            <span class="recent-path">{{ shortPath(file.path) }}</span>
+          </span>
+          <span class="recent-time">{{ relativeTime(file.last_opened) }}</span>
+        </button>
+      </div>
+      <div class="recent-empty" v-else>
+        No recent files yet
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  background: transparent;
+}
+
+.menu-panel {
+  position: fixed;
+  top: var(--titlebar-h);
+  left: calc(var(--sidebar-w) + 8px);
+  z-index: 501;
+  width: 312px;
+  background: rgba(250, 249, 247, 0.97);
+  backdrop-filter: blur(32px);
+  -webkit-backdrop-filter: blur(32px);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: menuIn 0.18s cubic-bezier(0.34, 1.2, 0.64, 1);
+  transform-origin: top left;
+}
+
+@keyframes menuIn {
+  from { opacity: 0; transform: scale(0.94) translateY(-6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.menu-logo {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.menu-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: background var(--t), color var(--t);
+}
+.menu-close:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+/* Actions */
+.menu-actions {
+  padding: 8px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--t);
+}
+.action-btn:hover {
+  background: var(--bg-chrome-active);
+}
+
+.action-icon {
+  width: 26px;
+  height: 26px;
+  background: var(--surface-solid);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  box-shadow: var(--shadow-xs);
+}
+
+.action-label {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.action-hint {
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  background: var(--bg-chrome-active);
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Recent */
+.recent-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 8px 0 4px;
+}
+
+.recent-label {
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-tertiary);
+  padding: 0 14px 6px;
+}
+
+.recent-list {
+  overflow-y: auto;
+  flex: 1;
+  padding: 0 8px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.recent-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 8px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--t);
+}
+.recent-item:hover {
+  background: var(--bg-chrome-active);
+}
+
+.recent-icon {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.recent-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.recent-title {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.recent-path {
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+}
+
+.recent-time {
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.recent-empty {
+  padding: 12px 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+</style>

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -57,7 +57,11 @@ async function handleRecent(file: RecentFile) {
       { path: file.path }
     )
     if (result.frontmatter.title) doc.docTitle.value = result.frontmatter.title
-    if (result.frontmatter.authors?.length) doc.docAuthors.value = result.frontmatter.authors
+    if (result.frontmatter.authors?.length) {
+      doc.docAuthors.value = result.frontmatter.authors.map((a: any) =>
+        typeof a === 'string' ? { name: a, orcid: '', title: '', affiliation: '' } : a
+      )
+    }
     doc.filePath.value = result.path
     doc.isDirty.value = false
     // Emit the content via events so WriteView can pick it up

--- a/src/components/LibraryEntryForm.vue
+++ b/src/components/LibraryEntryForm.vue
@@ -1,6 +1,27 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 import { useLibrary, type LibraryItem, type ItemInput } from '../composables/useLibrary'
+
+// ── Fetch types ───────────────────────────────────────────────────────────────
+
+interface FetchedMetadata {
+  title?:        string
+  authors?:      string
+  year?:         string
+  journal?:      string
+  volume?:       string
+  issue?:        string
+  pages?:        string
+  doi?:          string
+  issn?:         string
+  publisher?:    string
+  url?:          string
+  abstractText?: string
+  booktitle?:    string
+  isbn?:         string
+  entryType?:    string
+}
 
 const { createItem, updateItem, tags, displayItems, createTag, setItemTags } = useLibrary()
 
@@ -202,6 +223,93 @@ async function save() {
   }
 }
 
+// ── Metadata fetch ────────────────────────────────────────────────────────────
+
+const fetchId      = ref('')
+const fetching     = ref(false)
+const fetchError   = ref('')
+const fetchedMeta  = ref<FetchedMetadata | null>(null)
+const fetchSource  = ref('')
+
+function detectIdType(id: string): 'doi' | 'arxiv' | 'isbn' {
+  const s = id.trim()
+  if (/^10\.\d{4}/.test(s)) return 'doi'
+  if (/^(arXiv:|arxiv:)?\d{4}\.\d{4,5}(v\d+)?$/.test(s)) return 'arxiv'
+  if (/^(arXiv:|arxiv:)?[a-z-]+\/\d+$/i.test(s)) return 'arxiv'
+  const digits = s.replace(/[^0-9X]/gi, '')
+  if (digits.length === 10 || digits.length === 13) return 'isbn'
+  return 'doi'
+}
+
+async function fetchMetadata() {
+  const id = fetchId.value.trim()
+  if (!id) return
+  fetching.value = true
+  fetchError.value = ''
+  fetchedMeta.value = null
+  try {
+    const type = detectIdType(id)
+    if (type === 'doi') {
+      fetchSource.value = 'CrossRef'
+      fetchedMeta.value = await invoke<FetchedMetadata>('fetch_doi_metadata', { doi: id })
+    } else if (type === 'arxiv') {
+      fetchSource.value = 'arXiv'
+      fetchedMeta.value = await invoke<FetchedMetadata>('fetch_arxiv_metadata', { arxivId: id })
+    } else {
+      fetchSource.value = 'OpenLibrary'
+      fetchedMeta.value = await invoke<FetchedMetadata>('fetch_isbn_metadata', { isbn: id })
+    }
+  } catch (e) {
+    fetchError.value = String(e)
+  } finally {
+    fetching.value = false
+  }
+}
+
+const FETCH_FIELD_LABELS: Partial<Record<keyof FetchedMetadata, string>> = {
+  title: 'Title', authors: 'Authors', year: 'Year', journal: 'Journal',
+  volume: 'Volume', issue: 'Issue No.', pages: 'Pages', doi: 'DOI',
+  issn: 'ISSN', publisher: 'Publisher', url: 'URL', abstractText: 'Abstract',
+  booktitle: 'Conference', isbn: 'ISBN', entryType: 'Type',
+}
+
+const fetchedFields = computed(() => {
+  if (!fetchedMeta.value) return []
+  return (Object.keys(fetchedMeta.value) as (keyof FetchedMetadata)[])
+    .filter(k => fetchedMeta.value![k] !== undefined && FETCH_FIELD_LABELS[k])
+    .map(k => ({ key: k, label: FETCH_FIELD_LABELS[k]!, value: fetchedMeta.value![k]! }))
+})
+
+function applyFetchField(key: keyof FetchedMetadata) {
+  const val = fetchedMeta.value?.[key]
+  if (val === undefined) return
+  switch (key) {
+    case 'title':        title.value        = val; break
+    case 'authors':      authors.value      = val; break
+    case 'year':         year.value         = val; break
+    case 'journal':      journal.value      = val; break
+    case 'volume':       volume.value       = val; break
+    case 'issue':        number.value       = val; break
+    case 'pages':        pages.value        = val; break
+    case 'doi':          doi.value          = val; break
+    case 'issn':         issn.value         = val; break
+    case 'publisher':    publisher.value    = val; break
+    case 'url':          url.value          = val; break
+    case 'abstractText': abstractText.value = val; break
+    case 'booktitle':    booktitle.value    = val; break
+    case 'isbn':         isbn.value         = val; break
+    case 'entryType':    entryType.value    = val; break
+  }
+}
+
+function applyAllFetched() {
+  if (!fetchedMeta.value) return
+  for (const key of Object.keys(fetchedMeta.value) as (keyof FetchedMetadata)[]) {
+    applyFetchField(key)
+  }
+  fetchedMeta.value = null
+}
+
 function onBackdropClick(e: MouseEvent) {
   if (e.target === e.currentTarget) emit('close')
 }
@@ -225,6 +333,43 @@ function onBackdropClick(e: MouseEvent) {
 
         <!-- Body -->
         <div class="fs-body">
+
+          <!-- Metadata fetch -->
+          <div class="fetch-row">
+            <input
+              v-model="fetchId"
+              class="fs-input fetch-input"
+              placeholder="DOI, arXiv ID, or ISBN…"
+              @keydown.enter="fetchMetadata"
+            />
+            <button
+              class="fetch-btn"
+              :disabled="!fetchId.trim() || fetching"
+              @click="fetchMetadata"
+              type="button"
+            >{{ fetching ? '…' : 'Fetch' }}</button>
+          </div>
+
+          <!-- Fetch error -->
+          <p class="fetch-error" v-if="fetchError">{{ fetchError }}</p>
+
+          <!-- Fetch result diff panel -->
+          <div class="fetch-panel" v-if="fetchedMeta && fetchedFields.length">
+            <div class="fetch-panel-head">
+              <span class="fetch-panel-source">From {{ fetchSource }}</span>
+              <div class="fetch-panel-actions">
+                <button class="fetch-apply-all" @click="applyAllFetched" type="button">Apply All</button>
+                <button class="fetch-dismiss" @click="fetchedMeta = null" type="button">Dismiss</button>
+              </div>
+            </div>
+            <div class="fetch-fields">
+              <div v-for="f in fetchedFields" :key="f.key" class="fetch-field">
+                <span class="fetch-field-label">{{ f.label }}</span>
+                <span class="fetch-field-value">{{ f.value.length > 80 ? f.value.slice(0, 80) + '…' : f.value }}</span>
+                <button class="fetch-field-apply" @click="applyFetchField(f.key)" type="button">↓</button>
+              </div>
+            </div>
+          </div>
 
           <!-- Entry type row -->
           <div class="fs-field-row">
@@ -715,4 +860,143 @@ function onBackdropClick(e: MouseEvent) {
 
 .tag-add-confirm:hover { opacity: 0.8; }
 .tag-add-confirm:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Metadata fetch ──────────────────────────────────────────────────────────── */
+
+.fetch-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.fetch-input {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.fetch-btn {
+  height: 30px;
+  padding: 0 12px;
+  background: var(--bg-chrome-active);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background var(--t), opacity var(--t);
+  flex-shrink: 0;
+}
+.fetch-btn:hover:not(:disabled) { background: var(--accent); color: #fff; border-color: var(--accent); }
+.fetch-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.fetch-error {
+  font-size: 11.5px;
+  color: var(--accent-orange);
+  padding: 2px 0;
+}
+
+.fetch-panel {
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  background: var(--bg-chrome);
+  overflow: hidden;
+}
+
+.fetch-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 10px 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.fetch-panel-source {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--accent);
+}
+
+.fetch-panel-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.fetch-apply-all {
+  height: 24px;
+  padding: 0 10px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--t);
+}
+.fetch-apply-all:hover { opacity: 0.88; }
+
+.fetch-dismiss {
+  height: 24px;
+  padding: 0 8px;
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  transition: background var(--t);
+}
+.fetch-dismiss:hover { background: var(--bg-chrome-active); }
+
+.fetch-fields {
+  padding: 4px 0;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.fetch-field {
+  display: grid;
+  grid-template-columns: 72px 1fr 24px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+}
+
+.fetch-field-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  text-align: right;
+}
+
+.fetch-field-value {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fetch-field-apply {
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-xs);
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--accent);
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--t);
+}
+.fetch-field-apply:hover { background: var(--accent-soft); }
 </style>

--- a/src/components/LibraryEntryForm.vue
+++ b/src/components/LibraryEntryForm.vue
@@ -2,7 +2,7 @@
 import { ref, watch, computed } from 'vue'
 import { useLibrary, type LibraryItem, type ItemInput } from '../composables/useLibrary'
 
-const { createItem, updateItem } = useLibrary()
+const { createItem, updateItem, tags, displayItems, createTag, setItemTags } = useLibrary()
 
 const props = defineProps<{
   editItem?: LibraryItem | null
@@ -39,6 +39,49 @@ const note      = ref('')
 const saving   = ref(false)
 const keyError = ref('')
 let autoKey    = '' // tracks last auto-generated key to detect user override
+
+// ── Tags ──────────────────────────────────────────────────────────────────────
+
+const selectedTagIds = ref<number[]>([])
+const newTagInput = ref('')
+const TAG_COLORS = ['#0A5FBF', '#16963F', '#E8650A', '#7C3AED', '#C0392B', '#A5A4A2']
+
+watch(tags, (newTags) => {
+  if (props.editItem && selectedTagIds.value.length === 0 && props.editItem.tags.length > 0) {
+    selectedTagIds.value = newTags
+      .filter(t => props.editItem!.tags.includes(t.name))
+      .map(t => t.id)
+  }
+}, { immediate: true })
+
+function toggleTag(id: number) {
+  const idx = selectedTagIds.value.indexOf(id)
+  if (idx === -1) selectedTagIds.value = [...selectedTagIds.value, id]
+  else selectedTagIds.value = selectedTagIds.value.filter(i => i !== id)
+}
+
+async function addNewTag() {
+  const name = newTagInput.value.trim()
+  if (!name) return
+  const existing = tags.value.find(t => t.name.toLowerCase() === name.toLowerCase())
+  if (existing) {
+    if (!selectedTagIds.value.includes(existing.id)) {
+      selectedTagIds.value = [...selectedTagIds.value, existing.id]
+    }
+  } else {
+    const color = TAG_COLORS[tags.value.length % TAG_COLORS.length]
+    const created = await createTag(name, color)
+    selectedTagIds.value = [...selectedTagIds.value, created.id]
+  }
+  newTagInput.value = ''
+}
+
+function onTagInputKey(e: KeyboardEvent) {
+  if (e.key === 'Enter' || e.key === ',') {
+    e.preventDefault()
+    addNewTag()
+  }
+}
 
 function fillFrom(item: LibraryItem) {
   entryType.value    = item.entryType
@@ -144,7 +187,9 @@ async function save() {
     const result = isEdit.value
       ? await updateItem(props.editItem!.id, input)
       : await createItem(input)
-    emit('saved', result)
+    await setItemTags(result.id, selectedTagIds.value)
+    const freshItem = displayItems.value.find(i => i.id === result.id) ?? result
+    emit('saved', freshItem)
   } catch (e: unknown) {
     const msg = String(e)
     if (msg.includes('UNIQUE') || msg.includes('unique')) {
@@ -321,6 +366,42 @@ function onBackdropClick(e: MouseEvent) {
           <div class="fs-field-row">
             <label class="fs-label" for="ef-note">Note</label>
             <input id="ef-note" v-model="note" class="fs-input" placeholder="Miscellaneous note" />
+          </div>
+
+          <!-- Tags -->
+          <div class="fs-field-row fs-field-tags">
+            <label class="fs-label">Tags</label>
+            <div class="tag-section">
+              <div class="tag-chips" v-if="tags.length > 0">
+                <button
+                  v-for="tag in tags"
+                  :key="tag.id"
+                  class="tag-chip-btn"
+                  :class="{ selected: selectedTagIds.includes(tag.id) }"
+                  :style="selectedTagIds.includes(tag.id) ? {
+                    background: tag.color + '22',
+                    color: tag.color,
+                    borderColor: tag.color + '77',
+                  } : {}"
+                  @click="toggleTag(tag.id)"
+                  type="button"
+                >{{ tag.name }}</button>
+              </div>
+              <div class="tag-add-row">
+                <input
+                  v-model="newTagInput"
+                  class="fs-input tag-input"
+                  placeholder="New tag name…"
+                  @keydown="onTagInputKey"
+                />
+                <button
+                  class="tag-add-confirm"
+                  type="button"
+                  @click="addNewTag"
+                  :disabled="!newTagInput.trim()"
+                >Add</button>
+              </div>
+            </div>
           </div>
 
         </div>
@@ -567,4 +648,71 @@ function onBackdropClick(e: MouseEvent) {
 }
 .fs-btn.primary:hover { opacity: 0.88; }
 .fs-btn.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Tags section */
+.fs-field-tags {
+  align-items: flex-start;
+  padding-top: 4px;
+}
+
+.tag-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.tag-chip-btn {
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  background: none;
+  color: var(--text-secondary);
+  transition: background var(--t), color var(--t), border-color var(--t);
+}
+
+.tag-chip-btn:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+.tag-add-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.tag-input {
+  flex: 1;
+  height: 28px;
+}
+
+.tag-add-confirm {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
+  transition: opacity var(--t);
+  flex-shrink: 0;
+}
+
+.tag-add-confirm:hover { opacity: 0.8; }
+.tag-add-confirm:disabled { opacity: 0.4; cursor: not-allowed; }
 </style>

--- a/src/components/LibraryEntryForm.vue
+++ b/src/components/LibraryEntryForm.vue
@@ -1,0 +1,570 @@
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue'
+import { useLibrary, type LibraryItem, type ItemInput } from '../composables/useLibrary'
+
+const { createItem, updateItem } = useLibrary()
+
+const props = defineProps<{
+  editItem?: LibraryItem | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: [item: LibraryItem]
+}>()
+
+// ── Form state ────────────────────────────────────────────────────────────────
+
+const entryType = ref('article')
+const key       = ref('')
+const title     = ref('')
+const authors   = ref('')
+const year      = ref('')
+const journal   = ref('')
+const booktitle = ref('')
+const volume    = ref('')
+const number    = ref('')
+const pages     = ref('')
+const publisher = ref('')
+const institution = ref('')
+const edition   = ref('')
+const doi       = ref('')
+const url       = ref('')
+const isbn      = ref('')
+const issn      = ref('')
+const abstractText = ref('')
+const keywords  = ref('')
+const note      = ref('')
+
+const saving   = ref(false)
+const keyError = ref('')
+let autoKey    = '' // tracks last auto-generated key to detect user override
+
+function fillFrom(item: LibraryItem) {
+  entryType.value    = item.entryType
+  key.value          = item.key
+  title.value        = item.title       ?? ''
+  authors.value      = item.authors     ?? ''
+  year.value         = item.year        ?? ''
+  journal.value      = item.journal     ?? ''
+  booktitle.value    = item.booktitle   ?? ''
+  volume.value       = item.volume      ?? ''
+  number.value       = item.number      ?? ''
+  pages.value        = item.pages       ?? ''
+  publisher.value    = item.publisher   ?? ''
+  institution.value  = item.institution ?? ''
+  edition.value      = item.edition     ?? ''
+  doi.value          = item.doi         ?? ''
+  url.value          = item.url         ?? ''
+  isbn.value         = item.isbn        ?? ''
+  issn.value         = item.issn        ?? ''
+  abstractText.value = item.abstractText ?? ''
+  keywords.value     = item.keywords    ?? ''
+  note.value         = item.note        ?? ''
+}
+
+// Pre-fill when editing
+if (props.editItem) {
+  fillFrom(props.editItem)
+  autoKey = ''
+} else {
+  autoKey = ''
+}
+
+// ── Auto-key generation ───────────────────────────────────────────────────────
+
+function makeAutoKey(authorsStr: string, yearStr: string): string {
+  const firstAuthor = authorsStr.split(/[,&]| and /i)[0].trim()
+  const parts = firstAuthor.split(/\s+/)
+  const lastName = parts[parts.length - 1] ?? firstAuthor
+  const cleaned = lastName.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return cleaned && yearStr ? `${cleaned}${yearStr}` : ''
+}
+
+watch([authors, year], () => {
+  if (props.editItem) return  // don't auto-generate when editing
+  const candidate = makeAutoKey(authors.value, year.value)
+  if (!candidate) return
+  // Only update if key is empty or was last auto-set by us
+  if (key.value === '' || key.value === autoKey) {
+    autoKey = candidate
+    key.value = candidate
+  }
+})
+
+// ── Field visibility per type ─────────────────────────────────────────────────
+
+const showJournal     = computed(() => entryType.value === 'article')
+const showBooktitle   = computed(() => entryType.value === 'inproceedings')
+const showVolNum      = computed(() => ['article', 'book'].includes(entryType.value))
+const showPages       = computed(() => ['article', 'inproceedings'].includes(entryType.value))
+const showPublisher   = computed(() => ['book', 'misc'].includes(entryType.value))
+const showInstitution = computed(() => entryType.value === 'techreport')
+const showEdition     = computed(() => entryType.value === 'book')
+const showIsbn        = computed(() => entryType.value === 'book')
+const showIssn        = computed(() => entryType.value === 'article')
+
+const isEdit = computed(() => !!props.editItem)
+const formTitle = computed(() => isEdit.value ? 'Edit Entry' : 'Add Entry')
+
+// ── Save ──────────────────────────────────────────────────────────────────────
+
+async function save() {
+  keyError.value = ''
+  if (!key.value.trim()) {
+    keyError.value = 'Key is required'
+    return
+  }
+
+  const input: ItemInput = {
+    key:          key.value.trim(),
+    entryType:    entryType.value,
+    title:        title.value      || undefined,
+    authors:      authors.value    || undefined,
+    year:         year.value       || undefined,
+    journal:      journal.value    || undefined,
+    booktitle:    booktitle.value  || undefined,
+    volume:       volume.value     || undefined,
+    number:       number.value     || undefined,
+    pages:        pages.value      || undefined,
+    publisher:    publisher.value  || undefined,
+    institution:  institution.value || undefined,
+    edition:      edition.value    || undefined,
+    doi:          doi.value        || undefined,
+    url:          url.value        || undefined,
+    isbn:         isbn.value       || undefined,
+    issn:         issn.value       || undefined,
+    abstractText: abstractText.value || undefined,
+    keywords:     keywords.value   || undefined,
+    note:         note.value       || undefined,
+  }
+
+  saving.value = true
+  try {
+    const result = isEdit.value
+      ? await updateItem(props.editItem!.id, input)
+      : await createItem(input)
+    emit('saved', result)
+  } catch (e: unknown) {
+    const msg = String(e)
+    if (msg.includes('UNIQUE') || msg.includes('unique')) {
+      keyError.value = 'A key with that name already exists'
+    } else {
+      keyError.value = msg
+    }
+  } finally {
+    saving.value = false
+  }
+}
+
+function onBackdropClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="form-backdrop" @click="onBackdropClick">
+      <div class="form-sheet" role="dialog" :aria-label="formTitle">
+
+        <!-- Header -->
+        <div class="fs-header">
+          <span class="fs-title">{{ formTitle }}</span>
+          <button class="fs-close" @click="emit('close')" title="Close">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+              <line x1="1" y1="1" x2="12" y2="12"/>
+              <line x1="12" y1="1" x2="1" y2="12"/>
+            </svg>
+          </button>
+        </div>
+
+        <!-- Body -->
+        <div class="fs-body">
+
+          <!-- Entry type row -->
+          <div class="fs-field-row">
+            <label class="fs-label">Type</label>
+            <div class="type-tabs">
+              <button
+                v-for="t in ['article','book','inproceedings','techreport','misc']"
+                :key="t"
+                class="type-tab"
+                :class="{ active: entryType === t }"
+                @click="entryType = t"
+              >{{ t }}</button>
+            </div>
+          </div>
+
+          <!-- Key -->
+          <div class="fs-field-row" :class="{ error: keyError }">
+            <label class="fs-label" for="ef-key">Key <span class="required">*</span></label>
+            <div class="fs-input-wrap">
+              <input
+                id="ef-key"
+                v-model="key"
+                class="fs-input mono"
+                placeholder="e.g. smith2024"
+                autocomplete="off"
+                spellcheck="false"
+                @input="keyError = ''"
+              />
+              <span class="fs-error" v-if="keyError">{{ keyError }}</span>
+            </div>
+          </div>
+
+          <!-- Title -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-title">Title</label>
+            <input id="ef-title" v-model="title" class="fs-input" placeholder="Full title of the work" />
+          </div>
+
+          <!-- Authors -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-authors">Authors</label>
+            <input id="ef-authors" v-model="authors" class="fs-input" placeholder="Last, First and Last, First" />
+          </div>
+
+          <!-- Year -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-year">Year</label>
+            <input id="ef-year" v-model="year" class="fs-input short" placeholder="2024" maxlength="4" />
+          </div>
+
+          <!-- Journal (article only) -->
+          <div class="fs-field-row" v-if="showJournal">
+            <label class="fs-label" for="ef-journal">Journal</label>
+            <input id="ef-journal" v-model="journal" class="fs-input" placeholder="Journal name" />
+          </div>
+
+          <!-- Booktitle (inproceedings only) -->
+          <div class="fs-field-row" v-if="showBooktitle">
+            <label class="fs-label" for="ef-booktitle">Conference</label>
+            <input id="ef-booktitle" v-model="booktitle" class="fs-input" placeholder="Proceedings of..." />
+          </div>
+
+          <!-- Publisher (book, misc) -->
+          <div class="fs-field-row" v-if="showPublisher">
+            <label class="fs-label" for="ef-publisher">Publisher</label>
+            <input id="ef-publisher" v-model="publisher" class="fs-input" placeholder="Publisher name" />
+          </div>
+
+          <!-- Institution (techreport) -->
+          <div class="fs-field-row" v-if="showInstitution">
+            <label class="fs-label" for="ef-inst">Institution</label>
+            <input id="ef-inst" v-model="institution" class="fs-input" placeholder="Issuing institution" />
+          </div>
+
+          <!-- Volume + Number (article, book) -->
+          <div class="fs-field-row" v-if="showVolNum">
+            <label class="fs-label">Vol / No.</label>
+            <div class="fs-inline">
+              <input v-model="volume" class="fs-input short" placeholder="Vol" />
+              <input v-model="number" class="fs-input short" placeholder="No." />
+            </div>
+          </div>
+
+          <!-- Report number (techreport) -->
+          <div class="fs-field-row" v-if="entryType === 'techreport'">
+            <label class="fs-label" for="ef-number">Report No.</label>
+            <input id="ef-number" v-model="number" class="fs-input short" placeholder="Report number" />
+          </div>
+
+          <!-- Pages -->
+          <div class="fs-field-row" v-if="showPages">
+            <label class="fs-label" for="ef-pages">Pages</label>
+            <input id="ef-pages" v-model="pages" class="fs-input short" placeholder="100–115" />
+          </div>
+
+          <!-- Edition (book) -->
+          <div class="fs-field-row" v-if="showEdition">
+            <label class="fs-label" for="ef-edition">Edition</label>
+            <input id="ef-edition" v-model="edition" class="fs-input short" placeholder="2nd" />
+          </div>
+
+          <!-- DOI -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-doi">DOI</label>
+            <input id="ef-doi" v-model="doi" class="fs-input mono" placeholder="10.xxxx/..." />
+          </div>
+
+          <!-- ISBN (book) -->
+          <div class="fs-field-row" v-if="showIsbn">
+            <label class="fs-label" for="ef-isbn">ISBN</label>
+            <input id="ef-isbn" v-model="isbn" class="fs-input mono short" placeholder="978-..." />
+          </div>
+
+          <!-- ISSN (article) -->
+          <div class="fs-field-row" v-if="showIssn">
+            <label class="fs-label" for="ef-issn">ISSN</label>
+            <input id="ef-issn" v-model="issn" class="fs-input mono short" placeholder="1234-5678" />
+          </div>
+
+          <!-- URL -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-url">URL</label>
+            <input id="ef-url" v-model="url" class="fs-input" placeholder="https://..." />
+          </div>
+
+          <!-- Abstract -->
+          <div class="fs-field-row fs-field-tall">
+            <label class="fs-label" for="ef-abs">Abstract</label>
+            <textarea id="ef-abs" v-model="abstractText" class="fs-textarea" placeholder="Abstract text…" rows="4" />
+          </div>
+
+          <!-- Keywords -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-kw">Keywords</label>
+            <input id="ef-kw" v-model="keywords" class="fs-input" placeholder="keyword1, keyword2" />
+          </div>
+
+          <!-- Note -->
+          <div class="fs-field-row">
+            <label class="fs-label" for="ef-note">Note</label>
+            <input id="ef-note" v-model="note" class="fs-input" placeholder="Miscellaneous note" />
+          </div>
+
+        </div>
+
+        <!-- Footer -->
+        <div class="fs-footer">
+          <button class="fs-btn secondary" @click="emit('close')">Cancel</button>
+          <button class="fs-btn primary" @click="save" :disabled="saving">
+            {{ saving ? 'Saving…' : (isEdit ? 'Save Changes' : 'Add Entry') }}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.form-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.form-sheet {
+  background: var(--surface-solid);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 540px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Header */
+.fs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.fs-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.fs-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: background var(--t), color var(--t);
+}
+.fs-close:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+/* Body */
+.fs-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fs-field-row {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  align-items: center;
+  gap: 10px;
+  min-height: 32px;
+}
+
+.fs-field-row.fs-field-tall {
+  align-items: flex-start;
+  padding-top: 4px;
+}
+
+.fs-field-row.error .fs-input {
+  border-color: var(--accent-orange);
+}
+
+.fs-label {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.required {
+  color: var(--accent-orange);
+}
+
+.fs-input-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.fs-error {
+  font-size: 11px;
+  color: var(--accent-orange);
+}
+
+.fs-input {
+  width: 100%;
+  height: 30px;
+  padding: 0 9px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  color: var(--text);
+  background: var(--bg);
+  outline: none;
+  transition: border-color var(--t), box-shadow var(--t);
+}
+
+.fs-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2.5px var(--accent-soft);
+}
+
+.fs-input.mono {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.fs-input.short {
+  width: auto;
+  min-width: 80px;
+  max-width: 140px;
+}
+
+.fs-inline {
+  display: flex;
+  gap: 8px;
+}
+
+.fs-textarea {
+  width: 100%;
+  padding: 7px 9px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-doc);
+  font-size: 12.5px;
+  color: var(--text);
+  background: var(--bg);
+  outline: none;
+  resize: vertical;
+  line-height: 1.55;
+  transition: border-color var(--t), box-shadow var(--t);
+}
+
+.fs-textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2.5px var(--accent-soft);
+}
+
+/* Type tabs */
+.type-tabs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.type-tab {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--bg);
+  color: var(--text-secondary);
+  transition: background var(--t), color var(--t), border-color var(--t);
+}
+
+.type-tab:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+.type-tab.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+/* Footer */
+.fs-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 14px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.fs-btn {
+  height: 32px;
+  padding: 0 16px;
+  border-radius: var(--radius);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: opacity var(--t), background var(--t);
+}
+
+.fs-btn.secondary {
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
+}
+.fs-btn.secondary:hover { opacity: 0.8; }
+
+.fs-btn.primary {
+  background: var(--accent);
+  color: #fff;
+}
+.fs-btn.primary:hover { opacity: 0.88; }
+.fs-btn.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>

--- a/src/components/LibraryEntryForm.vue
+++ b/src/components/LibraryEntryForm.vue
@@ -231,8 +231,12 @@ const fetchError   = ref('')
 const fetchedMeta  = ref<FetchedMetadata | null>(null)
 const fetchSource  = ref('')
 
+function stripDoiUrl(s: string): string {
+  return s.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '').replace(/^doi:/i, '').trim()
+}
+
 function detectIdType(id: string): 'doi' | 'arxiv' | 'isbn' {
-  const s = id.trim()
+  const s = stripDoiUrl(id.trim())
   if (/^10\.\d{4}/.test(s)) return 'doi'
   if (/^(arXiv:|arxiv:)?\d{4}\.\d{4,5}(v\d+)?$/.test(s)) return 'arxiv'
   if (/^(arXiv:|arxiv:)?[a-z-]+\/\d+$/i.test(s)) return 'arxiv'

--- a/src/components/SectionRefNodeView.vue
+++ b/src/components/SectionRefNodeView.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { nodeViewProps, NodeViewWrapper } from '@tiptap/vue-3'
+
+const props = defineProps(nodeViewProps)
+
+// If the plugin set displayNum to '?' the heading was deleted
+const resolved = computed(() => props.node.attrs.displayNum !== '?')
+
+function onClick() {
+  const headingId = props.node.attrs.headingId as string
+  let headingPos: number | null = null
+  props.editor.state.doc.descendants((node: any, pos: number) => {
+    if (node.type.name === 'heading' && node.attrs.id === headingId) {
+      headingPos = pos
+      return false
+    }
+  })
+  if (headingPos !== null) {
+    props.editor.chain().setTextSelection(headingPos + 1).scrollIntoView().run()
+  }
+}
+</script>
+
+<template>
+  <NodeViewWrapper as="span" class="section-ref-inline">
+    <span
+      :class="['section-ref-node', { 'section-ref-unresolved': !resolved }]"
+      :title="resolved ? `Jump to § ${node.attrs.displayNum}` : 'Section not found'"
+      @click.stop="onClick"
+    >§ {{ node.attrs.displayNum }}</span>
+  </NodeViewWrapper>
+</template>

--- a/src/components/SectionRefSuggestList.vue
+++ b/src/components/SectionRefSuggestList.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+export interface SectionHeading {
+  id: string
+  text: string
+  displayNum: string
+  level: number
+}
+
+const props = defineProps<{
+  items: SectionHeading[]
+  command: (item: SectionHeading) => void
+}>()
+
+const selectedIndex = ref(0)
+
+watch(
+  () => props.items,
+  () => { selectedIndex.value = 0 },
+)
+
+function select(item: SectionHeading) {
+  props.command(item)
+}
+
+function onKeyDown(event: KeyboardEvent): boolean {
+  if (event.key === 'ArrowUp') {
+    selectedIndex.value = (selectedIndex.value - 1 + props.items.length) % props.items.length
+    return true
+  }
+  if (event.key === 'ArrowDown') {
+    selectedIndex.value = (selectedIndex.value + 1) % props.items.length
+    return true
+  }
+  if (event.key === 'Enter') {
+    const item = props.items[selectedIndex.value]
+    if (item) select(item)
+    return true
+  }
+  return false
+}
+
+defineExpose({ onKeyDown })
+</script>
+
+<template>
+  <div class="ref-suggest" v-if="items.length">
+    <div class="suggest-header">Jump to section</div>
+    <button
+      v-for="(item, i) in items"
+      :key="item.id"
+      class="ref-suggest-item"
+      :class="{ 'ref-suggest-item--active': i === selectedIndex }"
+      :style="{ paddingLeft: `${10 + (item.level - 1) * 14}px` }"
+      @mouseenter="selectedIndex = i"
+      @mousedown.prevent="select(item)"
+    >
+      <span class="ref-num">§ {{ item.displayNum }}</span>
+      <span class="ref-title">{{ item.text }}</span>
+    </button>
+  </div>
+  <div class="ref-suggest ref-suggest--empty" v-else>
+    No headings in this document
+  </div>
+</template>
+
+<style scoped>
+.ref-suggest {
+  background: rgba(252, 251, 249, 0.98);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.07);
+  min-width: 280px;
+  max-width: 360px;
+  overflow: hidden;
+  animation: suggestIn 0.14s cubic-bezier(0.34, 1.2, 0.64, 1);
+  transform-origin: top left;
+}
+
+@keyframes suggestIn {
+  from { opacity: 0; transform: scale(0.96) translateY(-4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.ref-suggest--empty {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #8E8E93;
+  font-style: italic;
+}
+
+.suggest-header {
+  padding: 7px 12px 5px;
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: #8E8E93;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+}
+
+.ref-suggest-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.ref-suggest-item--active {
+  background: rgba(124, 58, 237, 0.07);
+}
+
+.ref-num {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  color: #7C3AED;
+  background: rgba(124, 58, 237, 0.08);
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.ref-title {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: #1A1917;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+</style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -32,6 +32,19 @@ const route = useRoute()
       </router-link>
 
       <router-link
+        to="/library"
+        class="nav-item"
+        :class="{ active: route.name === 'library' }"
+        title="Library"
+      >
+        <svg width="17" height="17" viewBox="0 0 17 17" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 2.5h2.5v12H3z"/>
+          <path d="M7 2.5h2.5v12H7z"/>
+          <path d="M11.5 2.5l2.4.9-4.4 11.4-2.4-.9z"/>
+        </svg>
+      </router-link>
+
+      <router-link
         to="/pdf"
         class="nav-item"
         :class="{ active: route.name === 'pdf' }"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -45,6 +45,18 @@ const route = useRoute()
       </router-link>
 
       <router-link
+        to="/annotations"
+        class="nav-item"
+        :class="{ active: route.name === 'annotations' }"
+        title="Annotations"
+      >
+        <svg width="17" height="17" viewBox="0 0 17 17" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2.5 12.5L5 10l7.5-7.5a1.414 1.414 0 012 2L7 12l-2.5.5z"/>
+          <line x1="1.5" y1="15.5" x2="15.5" y2="15.5"/>
+        </svg>
+      </router-link>
+
+      <router-link
         to="/pdf"
         class="nav-item"
         :class="{ active: route.name === 'pdf' }"

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -1,3 +1,20 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDocument } from '../composables/useDocument'
+
+const { lastSaved, isDirty } = useDocument()
+
+const savedLabel = computed(() => {
+  if (isDirty.value) return 'Unsaved'
+  if (!lastSaved.value) return 'Saved'
+  const diff = Math.floor((Date.now() - lastSaved.value.getTime()) / 1000)
+  if (diff < 5) return 'Saved just now'
+  if (diff < 60) return `Saved ${diff}s ago`
+  const mins = Math.floor(diff / 60)
+  return `Saved ${mins}m ago`
+})
+</script>
+
 <template>
   <footer class="statusbar">
     <div class="status-left">
@@ -12,7 +29,7 @@
       </span>
     </div>
     <div class="status-right">
-      <span class="stat-item">Saved 2m ago</span>
+      <span class="stat-item" :class="{ unsaved: isDirty }">{{ savedLabel }}</span>
     </div>
   </footer>
 </template>
@@ -41,6 +58,10 @@
   font-size: 10.5px;
   color: var(--text-tertiary);
   letter-spacing: -0.005em;
+}
+
+.stat-item.unsaved {
+  color: var(--accent-orange);
 }
 
 .stat-sep {

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -3,6 +3,7 @@ interface Props {
   title: string
   subtitle: string
   exportLabel?: string | null
+  isDirty?: boolean
   onExport?: () => void
 }
 defineProps<Props>()
@@ -17,6 +18,7 @@ defineProps<Props>()
     </div>
 
     <div class="title-center">
+      <span v-if="isDirty" class="dirty-dot" title="Unsaved changes">●</span>
       <span class="doc-title">{{ title }}</span>
       <span v-if="subtitle" class="sep">—</span>
       <span v-if="subtitle" class="doc-subtitle">{{ subtitle }}</span>
@@ -75,6 +77,13 @@ defineProps<Props>()
   overflow: hidden;
 }
 
+.dirty-dot {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
 .doc-title {
   font-weight: 600;
   color: var(--text);
@@ -116,11 +125,11 @@ defineProps<Props>()
   letter-spacing: -0.01em;
 }
 .export-btn:hover {
-  background: rgba(0, 0, 0, 0.07);
-  border-color: rgba(0, 0, 0, 0.18);
+  background: rgba(0,0,0,0.07);
+  border-color: rgba(0,0,0,0.18);
   box-shadow: var(--shadow-xs);
 }
 .export-btn:active {
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0,0,0,0.1);
 }
 </style>

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -7,6 +7,7 @@ interface Props {
   onExport?: () => void
 }
 defineProps<Props>()
+const emit = defineEmits<{ toggleMenu: [] }>()
 </script>
 
 <template>
@@ -15,6 +16,13 @@ defineProps<Props>()
       <span class="dot red"></span>
       <span class="dot yellow"></span>
       <span class="dot green"></span>
+      <button class="hamburger" @click="emit('toggleMenu')" title="Menu">
+        <svg width="13" height="11" viewBox="0 0 13 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+          <line x1="0" y1="1.5" x2="13" y2="1.5"/>
+          <line x1="0" y1="5.5" x2="13" y2="5.5"/>
+          <line x1="0" y1="9.5" x2="13" y2="9.5"/>
+        </svg>
+      </button>
     </div>
 
     <div class="title-center">
@@ -51,8 +59,27 @@ defineProps<Props>()
   display: flex;
   gap: 6px;
   align-items: center;
-  width: 56px;
+  width: 88px;
   flex-shrink: 0;
+}
+
+.hamburger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: background var(--t), color var(--t);
+  margin-left: 2px;
+}
+.hamburger:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
 }
 
 .dot {

--- a/src/composables/useAnnotations.ts
+++ b/src/composables/useAnnotations.ts
@@ -1,0 +1,55 @@
+import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+
+export interface Annotation {
+  id: number
+  itemId: number
+  attachmentId: number
+  page: number
+  annType: string
+  color: string
+  selectedText?: string
+  noteText?: string
+  positionJson: string
+  createdAt: number
+}
+
+export interface AnnotationInput {
+  itemId: number
+  attachmentId: number
+  page: number
+  annType: string
+  color: string
+  selectedText?: string
+  noteText?: string
+  positionJson: string
+}
+
+export function useAnnotations() {
+  const annotations = ref<Annotation[]>([])
+
+  async function loadAnnotations(attachmentId: number): Promise<void> {
+    annotations.value = await invoke<Annotation[]>(
+      'get_annotations_for_attachment', { attachmentId }
+    )
+  }
+
+  async function createAnnotation(input: AnnotationInput): Promise<Annotation> {
+    const ann = await invoke<Annotation>('create_annotation', { input })
+    annotations.value.push(ann)
+    return ann
+  }
+
+  async function deleteAnnotation(id: number): Promise<void> {
+    await invoke('delete_annotation', { id })
+    annotations.value = annotations.value.filter(a => a.id !== id)
+  }
+
+  async function updateAnnotationNote(id: number, noteText: string): Promise<void> {
+    await invoke('update_annotation_note', { id, noteText })
+    const idx = annotations.value.findIndex(a => a.id === id)
+    if (idx !== -1) annotations.value[idx] = { ...annotations.value[idx], noteText }
+  }
+
+  return { annotations, loadAnnotations, createAnnotation, deleteAnnotation, updateAnnotationNote }
+}

--- a/src/composables/useAnnotations.ts
+++ b/src/composables/useAnnotations.ts
@@ -14,6 +14,23 @@ export interface Annotation {
   createdAt: number
 }
 
+export interface AnnotationWithSource {
+  id: number
+  itemId: number
+  attachmentId: number
+  page: number
+  annType: string
+  color: string
+  selectedText?: string
+  noteText?: string
+  createdAt: number
+  itemTitle?: string
+  itemAuthors?: string
+  itemYear?: string
+  itemKey: string
+  attachmentFileName: string
+}
+
 export interface AnnotationInput {
   itemId: number
   attachmentId: number
@@ -52,4 +69,38 @@ export function useAnnotations() {
   }
 
   return { annotations, loadAnnotations, createAnnotation, deleteAnnotation, updateAnnotationNote }
+}
+
+// Module-level singleton for the cross-source annotations list
+const allAnnotations = ref<AnnotationWithSource[]>([])
+const allAnnotationsLoading = ref(false)
+
+export function useAllAnnotations() {
+  async function loadAll(): Promise<void> {
+    allAnnotationsLoading.value = true
+    try {
+      allAnnotations.value = await invoke<AnnotationWithSource[]>('get_all_annotations')
+    } finally {
+      allAnnotationsLoading.value = false
+    }
+  }
+
+  async function deleteAndRefresh(id: number): Promise<void> {
+    await invoke('delete_annotation', { id })
+    allAnnotations.value = allAnnotations.value.filter(a => a.id !== id)
+  }
+
+  async function updateNoteAndRefresh(id: number, noteText: string): Promise<void> {
+    await invoke('update_annotation_note', { id, noteText })
+    const idx = allAnnotations.value.findIndex(a => a.id === id)
+    if (idx !== -1) allAnnotations.value[idx] = { ...allAnnotations.value[idx], noteText }
+  }
+
+  return {
+    allAnnotations,
+    allAnnotationsLoading,
+    loadAll,
+    deleteAndRefresh,
+    updateNoteAndRefresh,
+  }
 }

--- a/src/composables/useDocument.ts
+++ b/src/composables/useDocument.ts
@@ -1,0 +1,70 @@
+import { ref } from 'vue'
+
+export interface BibEntry {
+  key: string
+  entryType: string
+  title?: string
+  authors?: string
+  year?: string
+  journal?: string
+  doi?: string
+  abstractText?: string
+  url?: string
+}
+
+// Module-level singletons — shared across all components without Pinia
+const filePath = ref<string | null>(null)
+const bibPath = ref<string | null>(null)
+const docTitle = ref('Allergen Labelling Study')
+const docAuthors = ref<string[]>(['Sharma, R.', '[Author]'])
+const isDirty = ref(false)
+const lastSaved = ref<Date | null>(null)
+const citations = ref<BibEntry[]>([
+  {
+    key: 'popova2022',
+    entryType: 'article',
+    title: 'Allergen Labelling Compliance in Food Manufacturing: A Systematic Review',
+    authors: 'Popova, M., Chen, L., & Okafor, R.',
+    year: '2022',
+    journal: 'Food Control',
+    doi: '10.1016/j.foodcont.2022.108940',
+    abstractText:
+      'A systematic review examining allergen labelling compliance across 14 countries. Of 847 products sampled, 34% showed discrepancies between declared allergens and actual ingredient lists, with peanut and tree nut labelling showing the highest non-compliance rates. The study identifies inconsistent definition of precautionary labelling as a primary driver of consumer confusion.',
+  },
+  {
+    key: 'fda2021',
+    entryType: 'report',
+    title: 'Food Allergen Labeling and Consumer Protection Act: Compliance Report 2021',
+    authors: 'U.S. Food and Drug Administration',
+    year: '2021',
+    journal: 'FDA Technical Report',
+    doi: 'FDA-TR-2021-0042',
+    abstractText:
+      'Annual compliance report on FALCPA implementation, documenting a 1-in-8 consumer experience with allergic reactions attributable to labelling failures in packaged foods over a 24-month surveillance period. Survey conducted across n=12,400 households with at least one member reporting a food allergy.',
+  },
+  {
+    key: 'hadley2019',
+    entryType: 'article',
+    title: 'Hidden Allergens and Precautionary Labelling: Consumer Understanding and Risk',
+    authors: 'Hadley, C. & King, J.',
+    year: '2019',
+    journal: 'J Allergy Clin Immunol',
+    doi: '10.1016/j.jaci.2018.11.025',
+    abstractText:
+      'Cross-sectional study of consumer comprehension of precautionary allergen labels (PAL) across a 2019 baseline cohort. Finds significant variation in PAL interpretation by education level and prior allergy diagnosis. 67% of respondents misinterpreted "may contain" as indicating lower risk than a direct ingredient declaration.',
+  },
+])
+const citationOrder = ref<string[]>(['popova2022', 'fda2021', 'hadley2019'])
+
+export function useDocument() {
+  return {
+    filePath,
+    bibPath,
+    docTitle,
+    docAuthors,
+    isDirty,
+    lastSaved,
+    citations,
+    citationOrder,
+  }
+}

--- a/src/composables/useDocument.ts
+++ b/src/composables/useDocument.ts
@@ -25,11 +25,23 @@ export interface BibEntry {
   institution?: string
 }
 
+export interface DocAuthor {
+  name: string
+  orcid: string
+  title: string
+  affiliation: string
+}
+
 // Module-level singletons — shared across all components without Pinia
 const filePath = ref<string | null>(null)
 const bibPath = ref<string | null>(null)
 const docTitle = ref('Allergen Labelling Study')
-const docAuthors = ref<string[]>(['Sharma, R.', '[Author]'])
+const docSubtitle = ref('A Cross-Sectional Study of FSSAI Compliance and Consumer Risk Communication')
+const docStatus = ref('Working Draft')
+const docDate = ref('April 2026')
+const docAuthors = ref<DocAuthor[]>([
+  { name: 'Sharma, R.', orcid: '', title: 'PhD Candidate', affiliation: 'Food Policy Studies, IIT Madras' },
+])
 const isDirty = ref(false)
 const lastSaved = ref<Date | null>(null)
 const citations = ref<BibEntry[]>([
@@ -74,6 +86,9 @@ export function useDocument() {
     filePath,
     bibPath,
     docTitle,
+    docSubtitle,
+    docStatus,
+    docDate,
     docAuthors,
     isDirty,
     lastSaved,

--- a/src/composables/useDocument.ts
+++ b/src/composables/useDocument.ts
@@ -10,6 +10,19 @@ export interface BibEntry {
   doi?: string
   abstractText?: string
   url?: string
+  volume?: string
+  issue?: string
+  pages?: string
+  publisher?: string
+  booktitle?: string
+  edition?: string
+  month?: string
+  keywords?: string
+  note?: string
+  isbn?: string
+  issn?: string
+  number?: string
+  institution?: string
 }
 
 // Module-level singletons — shared across all components without Pinia

--- a/src/composables/useFileOps.ts
+++ b/src/composables/useFileOps.ts
@@ -17,7 +17,13 @@ export function useFileOps() {
       const result = await invoke<OpenResult>('open_document')
       filePath.value = result.path
       if (result.frontmatter.title) docTitle.value = result.frontmatter.title
-      if (result.frontmatter.authors?.length) docAuthors.value = result.frontmatter.authors
+      if (result.frontmatter.authors?.length) {
+        docAuthors.value = result.frontmatter.authors.map(a =>
+          typeof a === 'string'
+            ? { name: a, orcid: '', title: '', affiliation: '' }
+            : a
+        )
+      }
       isDirty.value = false
       emitter.emit('doc:opened', { path: result.path, content: result.body })
 

--- a/src/composables/useFileOps.ts
+++ b/src/composables/useFileOps.ts
@@ -1,0 +1,87 @@
+import { invoke } from '@tauri-apps/api/core'
+import { useDocument, type BibEntry } from './useDocument'
+import { emitter } from '../events'
+
+interface OpenResult {
+  path: string
+  content: string
+  frontmatter: { title?: string; authors?: string[]; date?: string }
+  body: string
+}
+
+export function useFileOps() {
+  const { filePath, bibPath, docTitle, docAuthors, isDirty, lastSaved, citations } = useDocument()
+
+  async function openDocument(): Promise<string | null> {
+    try {
+      const result = await invoke<OpenResult>('open_document')
+      filePath.value = result.path
+      if (result.frontmatter.title) docTitle.value = result.frontmatter.title
+      if (result.frontmatter.authors?.length) docAuthors.value = result.frontmatter.authors
+      isDirty.value = false
+      emitter.emit('doc:opened', { path: result.path, content: result.body })
+
+      // Auto-detect and load .bib
+      tryLoadBib(result.path)
+      return result.body
+    } catch (e) {
+      // User cancelled or error
+      return null
+    }
+  }
+
+  async function saveDocument(content: string): Promise<boolean> {
+    if (!filePath.value) {
+      return saveDocumentAs(content)
+    }
+    try {
+      await invoke('save_document', { path: filePath.value, content })
+      isDirty.value = false
+      lastSaved.value = new Date()
+      emitter.emit('doc:saved', { path: filePath.value })
+      return true
+    } catch (e) {
+      console.error('Save failed:', e)
+      return false
+    }
+  }
+
+  async function saveDocumentAs(content: string): Promise<boolean> {
+    try {
+      const newPath = await invoke<string>('save_document_as', { content })
+      filePath.value = newPath
+      isDirty.value = false
+      lastSaved.value = new Date()
+      emitter.emit('doc:saved', { path: newPath })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async function tryLoadBib(docPath: string) {
+    try {
+      const bib = await invoke<string | null>('find_bib_for_document', { docPath })
+      if (!bib) return
+      bibPath.value = bib
+      const entries = await invoke<BibEntry[]>('load_bib', { path: bib })
+      citations.value = entries
+      emitter.emit('bib:loaded')
+    } catch (e) {
+      console.warn('Could not load .bib:', e)
+    }
+  }
+
+  async function loadBibManual(path: string) {
+    try {
+      const entries = await invoke<BibEntry[]>('load_bib', { path })
+      bibPath.value = path
+      citations.value = entries
+      emitter.emit('bib:loaded')
+    } catch (e) {
+      console.error('Bib load failed:', e)
+    }
+  }
+
+  return { openDocument, saveDocument, saveDocumentAs, loadBibManual }
+}

--- a/src/composables/useLibrary.ts
+++ b/src/composables/useLibrary.ts
@@ -87,6 +87,14 @@ export interface Tag {
   color: string
 }
 
+export interface Attachment {
+  id: number
+  itemId: number
+  fileName: string
+  filePath: string
+  addedAt: number
+}
+
 // ── Singletons ────────────────────────────────────────────────────────────────
 
 const items        = ref<LibraryItem[]>([])   // full unfiltered list
@@ -267,6 +275,24 @@ export function useLibrary() {
     return invoke<number>('export_bib_file', { itemIds, path })
   }
 
+  // ── Attachments ─────────────────────────────────────────────────────────────
+
+  async function pickAndAttachFile(itemId: number): Promise<Attachment | null> {
+    return invoke<Attachment | null>('pick_and_attach_file', { itemId })
+  }
+
+  async function getItemAttachments(itemId: number): Promise<Attachment[]> {
+    return invoke<Attachment[]>('get_item_attachments', { itemId })
+  }
+
+  async function removeAttachment(id: number): Promise<void> {
+    return invoke('remove_attachment', { id })
+  }
+
+  async function openAttachmentExternal(id: number): Promise<void> {
+    return invoke('open_attachment_external', { id })
+  }
+
   return {
     // state
     items, displayItems, loading, error, collections, tags, filterQuery,
@@ -280,5 +306,7 @@ export function useLibrary() {
     loadTags, createTag, updateTagColor, deleteTag, setItemTags,
     // import / export
     importBibFile, exportBibFile,
+    // attachments
+    pickAndAttachFile, getItemAttachments, removeAttachment, openAttachmentExternal,
   }
 }

--- a/src/composables/useLibrary.ts
+++ b/src/composables/useLibrary.ts
@@ -57,6 +57,12 @@ export interface ItemInput {
   institution?: string
 }
 
+export interface ImportResult {
+  added:   number
+  skipped: number
+  errors:  string[]
+}
+
 export interface SearchQuery {
   text?: string
   entryTypes?: string[]
@@ -248,6 +254,19 @@ export function useLibrary() {
     await refreshAndFilter()
   }
 
+  // ── Import / Export ─────────────────────────────────────────────────────────
+
+  async function importBibFile(path: string, mode: string): Promise<ImportResult> {
+    const result = await invoke<ImportResult>('import_bib_file', { path, mode })
+    await refreshAndFilter()
+    await loadCollections()
+    return result
+  }
+
+  async function exportBibFile(itemIds: number[], path: string): Promise<number> {
+    return invoke<number>('export_bib_file', { itemIds, path })
+  }
+
   return {
     // state
     items, displayItems, loading, error, collections, tags, filterQuery,
@@ -259,5 +278,7 @@ export function useLibrary() {
     addItemToCollection, removeItemFromCollection, getItemCollectionIds,
     // tags
     loadTags, createTag, updateTagColor, deleteTag, setItemTags,
+    // import / export
+    importBibFile, exportBibFile,
   }
 }

--- a/src/composables/useLibrary.ts
+++ b/src/composables/useLibrary.ts
@@ -1,6 +1,8 @@
 import { ref } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
 export interface LibraryItem {
   id: number
   key: string
@@ -61,53 +63,201 @@ export interface SearchQuery {
   yearMin?: string
   yearMax?: string
   hasDoi?: boolean
+  collectionId?: number | null
+  tagName?: string | null
 }
 
-// Module-level singletons — same pattern as useDocument
-const items = ref<LibraryItem[]>([])
-const loading = ref(false)
-const error = ref<string | null>(null)
+export interface Collection {
+  id: number
+  name: string
+  parentId?: number | null
+  createdAt: number
+  itemCount: number
+}
+
+export interface Tag {
+  id: number
+  name: string
+  color: string
+}
+
+// ── Singletons ────────────────────────────────────────────────────────────────
+
+const items        = ref<LibraryItem[]>([])   // full unfiltered list
+const displayItems = ref<LibraryItem[]>([])   // currently shown (filtered)
+const loading      = ref(false)
+const error        = ref<string | null>(null)
+const collections  = ref<Collection[]>([])
+const tags         = ref<Tag[]>([])
+const filterQuery  = ref<SearchQuery>({})
+
+// ── Composable ────────────────────────────────────────────────────────────────
 
 export function useLibrary() {
+
+  // ── Item loading / filtering ────────────────────────────────────────────────
+
   async function loadItems(): Promise<void> {
     loading.value = true
     error.value = null
     try {
       items.value = await invoke<LibraryItem[]>('get_library_items')
+      displayItems.value = [...items.value]
     } catch (e) {
       error.value = String(e)
-      console.error('[library] Failed to load items:', e)
+      console.error('[library] loadItems:', e)
     } finally {
       loading.value = false
     }
+  }
+
+  function isQueryEmpty(q: SearchQuery): boolean {
+    return !q.text && !q.collectionId && !q.tagName && !q.hasDoi &&
+           (!q.entryTypes || q.entryTypes.length === 0) && !q.yearMin && !q.yearMax
+  }
+
+  async function applyFilter(): Promise<void> {
+    if (isQueryEmpty(filterQuery.value)) {
+      displayItems.value = [...items.value]
+      return
+    }
+    try {
+      displayItems.value = await invoke<LibraryItem[]>('search_library_items', {
+        query: filterQuery.value,
+      })
+    } catch (e) {
+      console.error('[library] applyFilter:', e)
+    }
+  }
+
+  async function refreshAndFilter(): Promise<void> {
+    items.value = await invoke<LibraryItem[]>('get_library_items')
+    await applyFilter()
+  }
+
+  // ── CRUD ────────────────────────────────────────────────────────────────────
+
+  async function createItem(input: ItemInput): Promise<LibraryItem> {
+    const created = await invoke<LibraryItem>('create_library_item', { item: input })
+    await refreshAndFilter()
+    return created
+  }
+
+  async function updateItem(id: number, input: ItemInput): Promise<LibraryItem> {
+    const updated = await invoke<LibraryItem>('update_library_item', { id, item: input })
+    await refreshAndFilter()
+    return updated
+  }
+
+  async function deleteItem(id: number): Promise<void> {
+    await invoke('delete_library_item', { id })
+    await refreshAndFilter()
   }
 
   async function searchItems(query: SearchQuery): Promise<LibraryItem[]> {
     try {
       return await invoke<LibraryItem[]>('search_library_items', { query })
     } catch (e) {
-      console.error('[library] Search failed:', e)
+      console.error('[library] searchItems:', e)
       return []
     }
   }
 
-  async function createItem(input: ItemInput): Promise<LibraryItem> {
-    const created = await invoke<LibraryItem>('create_library_item', { item: input })
-    items.value.unshift(created)
-    return created
+  // ── Collections ─────────────────────────────────────────────────────────────
+
+  async function loadCollections(): Promise<void> {
+    try {
+      collections.value = await invoke<Collection[]>('get_collections')
+    } catch (e) {
+      console.error('[library] loadCollections:', e)
+    }
   }
 
-  async function updateItem(id: number, input: ItemInput): Promise<LibraryItem> {
-    const updated = await invoke<LibraryItem>('update_library_item', { id, item: input })
-    const idx = items.value.findIndex(i => i.id === id)
-    if (idx !== -1) items.value[idx] = updated
-    return updated
+  async function createCollection(name: string, parentId?: number): Promise<Collection> {
+    const col = await invoke<Collection>('create_collection', { name, parentId: parentId ?? null })
+    collections.value.push(col)
+    return col
   }
 
-  async function deleteItem(id: number): Promise<void> {
-    await invoke('delete_library_item', { id })
-    items.value = items.value.filter(i => i.id !== id)
+  async function renameCollection(id: number, name: string): Promise<void> {
+    const updated = await invoke<Collection>('rename_collection', { id, name })
+    const idx = collections.value.findIndex(c => c.id === id)
+    if (idx !== -1) collections.value[idx] = updated
   }
 
-  return { items, loading, error, loadItems, searchItems, createItem, updateItem, deleteItem }
+  async function deleteCollection(id: number): Promise<void> {
+    await invoke('delete_collection', { id })
+    collections.value = collections.value.filter(c => c.id !== id)
+    if (filterQuery.value.collectionId === id) {
+      filterQuery.value = { ...filterQuery.value, collectionId: null }
+      await applyFilter()
+    }
+  }
+
+  async function addItemToCollection(collectionId: number, itemId: number): Promise<void> {
+    await invoke('add_item_to_collection', { collectionId, itemId })
+    await loadCollections()
+  }
+
+  async function removeItemFromCollection(collectionId: number, itemId: number): Promise<void> {
+    await invoke('remove_item_from_collection', { collectionId, itemId })
+    await loadCollections()
+  }
+
+  async function getItemCollectionIds(itemId: number): Promise<number[]> {
+    return invoke<number[]>('get_item_collection_ids', { itemId })
+  }
+
+  // ── Tags ────────────────────────────────────────────────────────────────────
+
+  async function loadTags(): Promise<void> {
+    try {
+      tags.value = await invoke<Tag[]>('get_tags')
+    } catch (e) {
+      console.error('[library] loadTags:', e)
+    }
+  }
+
+  async function createTag(name: string, color: string): Promise<Tag> {
+    const tag = await invoke<Tag>('create_tag', { name, color })
+    tags.value.push(tag)
+    tags.value.sort((a, b) => a.name.localeCompare(b.name))
+    return tag
+  }
+
+  async function updateTagColor(id: number, color: string): Promise<void> {
+    const updated = await invoke<Tag>('update_tag_color', { id, color })
+    const idx = tags.value.findIndex(t => t.id === id)
+    if (idx !== -1) tags.value[idx] = updated
+  }
+
+  async function deleteTag(id: number): Promise<void> {
+    await invoke('delete_tag', { id })
+    tags.value = tags.value.filter(t => t.id !== id)
+    if (filterQuery.value.tagName) {
+      const removed = tags.value.find(t => t.id === id)
+      if (removed?.name === filterQuery.value.tagName) {
+        filterQuery.value = { ...filterQuery.value, tagName: null }
+        await applyFilter()
+      }
+    }
+  }
+
+  async function setItemTags(itemId: number, tagIds: number[]): Promise<void> {
+    await invoke('set_item_tags', { itemId, tagIds })
+    await refreshAndFilter()
+  }
+
+  return {
+    // state
+    items, displayItems, loading, error, collections, tags, filterQuery,
+    // items
+    loadItems, applyFilter, refreshAndFilter,
+    createItem, updateItem, deleteItem, searchItems,
+    // collections
+    loadCollections, createCollection, renameCollection, deleteCollection,
+    addItemToCollection, removeItemFromCollection, getItemCollectionIds,
+    // tags
+    loadTags, createTag, updateTagColor, deleteTag, setItemTags,
+  }
 }

--- a/src/composables/useLibrary.ts
+++ b/src/composables/useLibrary.ts
@@ -30,6 +30,31 @@ export interface LibraryItem {
   tags: string[]
 }
 
+export interface ItemInput {
+  key: string
+  entryType: string
+  title?: string
+  authors?: string
+  year?: string
+  journal?: string
+  doi?: string
+  abstractText?: string
+  url?: string
+  volume?: string
+  issue?: string
+  pages?: string
+  publisher?: string
+  booktitle?: string
+  edition?: string
+  month?: string
+  keywords?: string
+  note?: string
+  isbn?: string
+  issn?: string
+  number?: string
+  institution?: string
+}
+
 export interface SearchQuery {
   text?: string
   entryTypes?: string[]
@@ -66,10 +91,23 @@ export function useLibrary() {
     }
   }
 
+  async function createItem(input: ItemInput): Promise<LibraryItem> {
+    const created = await invoke<LibraryItem>('create_library_item', { item: input })
+    items.value.unshift(created)
+    return created
+  }
+
+  async function updateItem(id: number, input: ItemInput): Promise<LibraryItem> {
+    const updated = await invoke<LibraryItem>('update_library_item', { id, item: input })
+    const idx = items.value.findIndex(i => i.id === id)
+    if (idx !== -1) items.value[idx] = updated
+    return updated
+  }
+
   async function deleteItem(id: number): Promise<void> {
     await invoke('delete_library_item', { id })
     items.value = items.value.filter(i => i.id !== id)
   }
 
-  return { items, loading, error, loadItems, searchItems, deleteItem }
+  return { items, loading, error, loadItems, searchItems, createItem, updateItem, deleteItem }
 }

--- a/src/composables/useLibrary.ts
+++ b/src/composables/useLibrary.ts
@@ -1,0 +1,75 @@
+import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+
+export interface LibraryItem {
+  id: number
+  key: string
+  entryType: string
+  title?: string
+  authors?: string
+  year?: string
+  journal?: string
+  doi?: string
+  abstractText?: string
+  url?: string
+  volume?: string
+  issue?: string
+  pages?: string
+  publisher?: string
+  booktitle?: string
+  edition?: string
+  month?: string
+  keywords?: string
+  note?: string
+  isbn?: string
+  issn?: string
+  number?: string
+  institution?: string
+  addedAt: number
+  updatedAt: number
+  tags: string[]
+}
+
+export interface SearchQuery {
+  text?: string
+  entryTypes?: string[]
+  yearMin?: string
+  yearMax?: string
+  hasDoi?: boolean
+}
+
+// Module-level singletons — same pattern as useDocument
+const items = ref<LibraryItem[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+export function useLibrary() {
+  async function loadItems(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      items.value = await invoke<LibraryItem[]>('get_library_items')
+    } catch (e) {
+      error.value = String(e)
+      console.error('[library] Failed to load items:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function searchItems(query: SearchQuery): Promise<LibraryItem[]> {
+    try {
+      return await invoke<LibraryItem[]>('search_library_items', { query })
+    } catch (e) {
+      console.error('[library] Search failed:', e)
+      return []
+    }
+  }
+
+  async function deleteItem(id: number): Promise<void> {
+    await invoke('delete_library_item', { id })
+    items.value = items.value.filter(i => i.id !== id)
+  }
+
+  return { items, loading, error, loadItems, searchItems, deleteItem }
+}

--- a/src/composables/useQuire.ts
+++ b/src/composables/useQuire.ts
@@ -1,0 +1,53 @@
+import { invoke } from '@tauri-apps/api/core'
+import { useDocument } from './useDocument'
+
+export interface RecentFile {
+  path: string
+  title: string
+  last_opened: string // unix seconds as string
+}
+
+export function useQuire() {
+  const { citations, bibPath } = useDocument()
+
+  async function initQuire(): Promise<void> {
+    try {
+      const dir = await invoke<string>('get_quire_dir')
+      bibPath.value = `${dir}/references.bib`
+      const entries = await invoke<typeof citations.value>('get_global_bib')
+      citations.value = entries
+    } catch (e) {
+      console.error('[quire] Failed to init:', e)
+    }
+  }
+
+  async function getRecentFiles(): Promise<RecentFile[]> {
+    try {
+      return await invoke<RecentFile[]>('get_recent_files')
+    } catch {
+      return []
+    }
+  }
+
+  async function addRecentFile(path: string, title: string): Promise<void> {
+    try {
+      await invoke('add_recent_file', { path, title })
+    } catch (e) {
+      console.warn('[quire] Could not update recent files:', e)
+    }
+  }
+
+  /** Human-readable relative time from a unix-seconds string */
+  function relativeTime(unixSecsStr: string): string {
+    const secs = parseInt(unixSecsStr, 10)
+    if (isNaN(secs)) return ''
+    const diff = Math.floor(Date.now() / 1000) - secs
+    if (diff < 60) return 'Just now'
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+    if (diff < 172800) return 'Yesterday'
+    return `${Math.floor(diff / 86400)}d ago`
+  }
+
+  return { initQuire, getRecentFiles, addRecentFile, relativeTime }
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,15 @@
+import mitt from 'mitt'
+
+export type Events = {
+  'cite:hover': { key: string; rect: DOMRect }
+  'cite:leave': void
+  'cite:click': { key: string }
+  'doc:saved': { path: string }
+  'doc:opened': { path: string; content: string }
+  'bib:loaded': void
+  'export:start': void
+  'export:done': { outputPath: string }
+  'export:error': { message: string }
+}
+
+export const emitter = mitt<Events>()

--- a/src/extensions/CitationNode.ts
+++ b/src/extensions/CitationNode.ts
@@ -1,0 +1,41 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import CitationNodeView from '../components/CitationNodeView.vue'
+
+export const CitationNode = Node.create({
+  name: 'citation',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      citeKey: {
+        default: null,
+        parseHTML: el => el.getAttribute('data-cite-key'),
+        renderHTML: attrs => ({ 'data-cite-key': attrs.citeKey }),
+      },
+      displayIndex: {
+        default: 1,
+        parseHTML: el => parseInt(el.getAttribute('data-index') ?? '1', 10),
+        renderHTML: attrs => ({ 'data-index': String(attrs.displayIndex) }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-cite-key]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, { class: 'cite-node-rendered' }),
+      `[${HTMLAttributes['data-index']}]`,
+    ]
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(CitationNodeView)
+  },
+})

--- a/src/extensions/CitationSuggest.ts
+++ b/src/extensions/CitationSuggest.ts
@@ -1,0 +1,127 @@
+import { Extension } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import { VueRenderer } from '@tiptap/vue-3'
+import CitationSuggestList from '../components/CitationSuggestList.vue'
+import { useDocument, type BibEntry } from '../composables/useDocument'
+
+export const CitationSuggest = Extension.create({
+  name: 'citationSuggest',
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: '@',
+        allowSpaces: false,
+
+        items({ query }: { query: string }): BibEntry[] {
+          const { citations } = useDocument()
+          const q = query.toLowerCase()
+          const all = citations.value
+          if (!q) return all.slice(0, 8)
+          return all
+            .filter(
+              c =>
+                c.key.toLowerCase().includes(q) ||
+                (c.title ?? '').toLowerCase().includes(q) ||
+                (c.authors ?? '').toLowerCase().includes(q),
+            )
+            .slice(0, 8)
+        },
+
+        render() {
+          let renderer: VueRenderer
+          let wrapper: HTMLDivElement
+
+          return {
+            onStart(props: any) {
+              wrapper = document.createElement('div')
+              wrapper.style.cssText = 'position:fixed;z-index:9999;'
+              document.body.appendChild(wrapper)
+
+              renderer = new VueRenderer(CitationSuggestList, {
+                props,
+                editor: props.editor,
+              })
+              wrapper.appendChild(renderer.el!)
+
+              const rect: DOMRect | undefined = props.clientRect?.()
+              if (rect) {
+                wrapper.style.left = `${rect.left}px`
+                wrapper.style.top = `${rect.bottom + 4}px`
+              }
+            },
+
+            onUpdate(props: any) {
+              renderer.updateProps(props)
+
+              const rect: DOMRect | undefined = props.clientRect?.()
+              if (rect) {
+                wrapper.style.left = `${rect.left}px`
+                wrapper.style.top = `${rect.bottom + 4}px`
+              }
+            },
+
+            onKeyDown({ event }: { event: KeyboardEvent }): boolean {
+              if (event.key === 'Escape') {
+                wrapper.style.display = 'none'
+                return true
+              }
+              return (renderer.ref as any)?.onKeyDown(event) ?? false
+            },
+
+            onExit() {
+              renderer.destroy()
+              wrapper.remove()
+            },
+          }
+        },
+
+        command({
+          editor,
+          range,
+          props: entry,
+        }: {
+          editor: any
+          range: any
+          props: BibEntry
+        }) {
+          // Compute next sequential index, or reuse existing one for this key
+          const usedKeys = new Map<string, number>()
+          let maxIndex = 0
+          editor.state.doc.descendants((node: any) => {
+            if (node.type.name === 'citation') {
+              const k = node.attrs.citeKey as string
+              const idx = node.attrs.displayIndex as number
+              if (!usedKeys.has(k)) {
+                usedKeys.set(k, idx)
+                maxIndex = Math.max(maxIndex, idx)
+              }
+            }
+          })
+          const displayIndex = usedKeys.has(entry.key)
+            ? usedKeys.get(entry.key)!
+            : maxIndex + 1
+
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({
+              type: 'citation',
+              attrs: { citeKey: entry.key, displayIndex },
+            })
+            .run()
+        },
+      },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ]
+  },
+})

--- a/src/extensions/SearchAndReplace.ts
+++ b/src/extensions/SearchAndReplace.ts
@@ -1,0 +1,151 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    searchAndReplace: {
+      setSearch: (term: string) => ReturnType
+      findNext: () => ReturnType
+      findPrev: () => ReturnType
+      replaceOne: (replacement: string) => ReturnType
+      replaceAll: (replacement: string) => ReturnType
+    }
+  }
+}
+
+export interface SearchState {
+  term: string
+  matches: { from: number; to: number }[]
+  current: number
+}
+
+export const searchKey = new PluginKey<SearchState>('searchReplace')
+
+function findMatches(doc: any, term: string): { from: number; to: number }[] {
+  if (!term) return []
+  const results: { from: number; to: number }[] = []
+  const lower = term.toLowerCase()
+  doc.descendants((node: any, pos: number) => {
+    if (!node.isText || !node.text) return
+    const text = (node.text as string).toLowerCase()
+    let i = text.indexOf(lower)
+    while (i !== -1) {
+      results.push({ from: pos + i, to: pos + i + term.length })
+      i = text.indexOf(lower, i + 1)
+    }
+  })
+  return results
+}
+
+export const SearchAndReplace = Extension.create({
+  name: 'searchAndReplace',
+
+  addCommands() {
+    return {
+      setSearch:
+        (term: string) =>
+        ({ tr, state, dispatch }: any) => {
+          const matches = findMatches(state.doc, term)
+          if (dispatch) dispatch(tr.setMeta(searchKey, { term, matches, current: -1 }))
+          return true
+        },
+
+      findNext:
+        () =>
+        ({ tr, state, dispatch }: any) => {
+          const ps: SearchState = searchKey.getState(state)!
+          if (!ps.matches.length) return false
+          const next = (ps.current + 1) % ps.matches.length
+          const m = ps.matches[next]
+          if (dispatch) {
+            dispatch(
+              tr
+                .setMeta(searchKey, { ...ps, current: next })
+                .setSelection(TextSelection.create(tr.doc, m.from, m.to))
+                .scrollIntoView()
+            )
+          }
+          return true
+        },
+
+      findPrev:
+        () =>
+        ({ tr, state, dispatch }: any) => {
+          const ps: SearchState = searchKey.getState(state)!
+          if (!ps.matches.length) return false
+          const prev = (ps.current - 1 + ps.matches.length) % ps.matches.length
+          const m = ps.matches[prev]
+          if (dispatch) {
+            dispatch(
+              tr
+                .setMeta(searchKey, { ...ps, current: prev })
+                .setSelection(TextSelection.create(tr.doc, m.from, m.to))
+                .scrollIntoView()
+            )
+          }
+          return true
+        },
+
+      replaceOne:
+        (replacement: string) =>
+        ({ tr, state, dispatch }: any) => {
+          const ps: SearchState = searchKey.getState(state)!
+          if (!ps.matches.length || ps.current < 0) return false
+          const { from, to } = ps.matches[ps.current]
+          tr.insertText(replacement, from, to)
+          const newMatches = findMatches(tr.doc, ps.term)
+          const newCurrent = Math.min(ps.current, newMatches.length - 1)
+          if (dispatch) dispatch(tr.setMeta(searchKey, { term: ps.term, matches: newMatches, current: newCurrent }))
+          return true
+        },
+
+      replaceAll:
+        (replacement: string) =>
+        ({ tr, state, dispatch }: any) => {
+          const ps: SearchState = searchKey.getState(state)!
+          if (!ps.matches.length) return false
+          for (let i = ps.matches.length - 1; i >= 0; i--) {
+            const from = tr.mapping.map(ps.matches[i].from)
+            const to = tr.mapping.map(ps.matches[i].to)
+            tr.insertText(replacement, from, to)
+          }
+          if (dispatch) dispatch(tr.setMeta(searchKey, { term: ps.term, matches: [], current: -1 }))
+          return true
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: searchKey,
+        state: {
+          init(): SearchState {
+            return { term: '', matches: [], current: -1 }
+          },
+          apply(tr, prev): SearchState {
+            const meta = tr.getMeta(searchKey)
+            if (meta) return meta
+            if (tr.docChanged && prev.term) {
+              return { ...prev, matches: findMatches(tr.doc, prev.term) }
+            }
+            return prev
+          },
+        },
+        props: {
+          decorations(state) {
+            const ps = searchKey.getState(state)!
+            if (!ps.term || !ps.matches.length) return DecorationSet.empty
+            const decos = ps.matches.map((m, i) =>
+              Decoration.inline(m.from, m.to, {
+                class: i === ps.current ? 'search-current' : 'search-match',
+              })
+            )
+            return DecorationSet.create(state.doc, decos)
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/src/extensions/SectionRef.ts
+++ b/src/extensions/SectionRef.ts
@@ -1,0 +1,102 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { VueNodeViewRenderer } from '@tiptap/vue-3'
+import SectionRefNodeView from '../components/SectionRefNodeView.vue'
+
+export const sectionRefKey = new PluginKey('sectionRef')
+
+// Mirrors the CSS counter logic in editor.css exactly.
+export function computeHeadingMap(doc: any): Map<string, string> {
+  const map = new Map<string, string>()
+  let s = 0
+  let ss = 0
+  let sss = 0
+  doc.descendants((node: any) => {
+    if (node.type.name !== 'heading') return
+    const id = node.attrs.id as string | null
+    const level = node.attrs.level as number
+    if (level === 1) { s++; ss = 0; sss = 0; if (id) map.set(id, `${s}`) }
+    else if (level === 2) { ss++; sss = 0; if (id) map.set(id, `${s}.${ss}`) }
+    else if (level === 3) { sss++; if (id) map.set(id, `${s}.${ss}.${sss}`) }
+  })
+  return map
+}
+
+export const SectionRef = Node.create({
+  name: 'sectionRef',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      headingId: {
+        default: null,
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-ref-id'),
+        renderHTML: (attrs: any) => ({ 'data-ref-id': attrs.headingId }),
+      },
+      displayNum: {
+        default: '?',
+        parseHTML: (el: HTMLElement) => el.getAttribute('data-ref-num') ?? '?',
+        renderHTML: (attrs: any) => ({ 'data-ref-num': attrs.displayNum }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-ref-id]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, { class: 'section-ref-rendered' }),
+      `§ ${HTMLAttributes['data-ref-num']}`,
+    ]
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(SectionRefNodeView)
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: sectionRefKey,
+        appendTransaction(transactions, _oldState, newState) {
+          // Prevent re-entry: skip if any transaction in this batch is ours
+          if (transactions.some(tr => tr.getMeta('headingRefSync'))) return null
+
+          const docChanged = transactions.some(tr => tr.docChanged)
+          if (!docChanged) return null
+
+          const tr = newState.tr
+          let changed = false
+
+          // Job 1: assign stable UUIDs to any heading that lacks one
+          newState.doc.descendants((node: any, pos: number) => {
+            if (node.type.name === 'heading' && !node.attrs.id) {
+              tr.setNodeMarkup(pos, undefined, { ...node.attrs, id: crypto.randomUUID() })
+              changed = true
+            }
+          })
+
+          // Job 2: sync sectionRef displayNum using tr.doc (includes Job 1 IDs)
+          const headingMap = computeHeadingMap(tr.doc)
+          tr.doc.descendants((node: any, pos: number) => {
+            if (node.type.name !== 'sectionRef') return
+            const newNum = headingMap.get(node.attrs.headingId) ?? '?'
+            if (node.attrs.displayNum !== newNum) {
+              tr.setNodeMarkup(pos, undefined, { ...node.attrs, displayNum: newNum })
+              changed = true
+            }
+          })
+
+          if (!changed) return null
+          tr.setMeta('headingRefSync', true)
+          return tr
+        },
+      }),
+    ]
+  },
+})

--- a/src/extensions/SectionRefSuggest.ts
+++ b/src/extensions/SectionRefSuggest.ts
@@ -1,0 +1,114 @@
+import { Extension } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import { PluginKey } from '@tiptap/pm/state'
+import { VueRenderer } from '@tiptap/vue-3'
+import SectionRefSuggestList, { type SectionHeading } from '../components/SectionRefSuggestList.vue'
+import { computeHeadingMap } from './SectionRef'
+
+const sectionRefSuggestKey = new PluginKey('sectionRefSuggest')
+
+export const SectionRefSuggest = Extension.create({
+  name: 'sectionRefSuggest',
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: '[[',
+        pluginKey: sectionRefSuggestKey,
+        allowSpaces: true,
+
+        items({ query, editor }: { query: string; editor: any }): SectionHeading[] {
+          const doc = editor.state.doc
+          const headingMap = computeHeadingMap(doc)
+          const results: SectionHeading[] = []
+          doc.descendants((node: any) => {
+            if (node.type.name !== 'heading') return
+            const id = node.attrs.id as string | null
+            if (!id) return
+            const displayNum = headingMap.get(id) ?? '?'
+            results.push({ id, text: node.textContent as string, displayNum, level: node.attrs.level })
+          })
+          if (!query) return results.slice(0, 10)
+          const q = query.toLowerCase()
+          return results.filter(h => h.text.toLowerCase().includes(q)).slice(0, 10)
+        },
+
+        render() {
+          let renderer: VueRenderer
+          let wrapper: HTMLDivElement
+
+          return {
+            onStart(props: any) {
+              wrapper = document.createElement('div')
+              wrapper.style.cssText = 'position:fixed;z-index:9999;'
+              document.body.appendChild(wrapper)
+
+              renderer = new VueRenderer(SectionRefSuggestList, {
+                props,
+                editor: props.editor,
+              })
+              wrapper.appendChild(renderer.el!)
+
+              const rect: DOMRect | undefined = props.clientRect?.()
+              if (rect) {
+                wrapper.style.left = `${rect.left}px`
+                wrapper.style.top = `${rect.bottom + 4}px`
+              }
+            },
+
+            onUpdate(props: any) {
+              renderer.updateProps(props)
+              const rect: DOMRect | undefined = props.clientRect?.()
+              if (rect) {
+                wrapper.style.left = `${rect.left}px`
+                wrapper.style.top = `${rect.bottom + 4}px`
+              }
+            },
+
+            onKeyDown({ event }: { event: KeyboardEvent }): boolean {
+              if (event.key === 'Escape') {
+                wrapper.style.display = 'none'
+                return true
+              }
+              return (renderer.ref as any)?.onKeyDown(event) ?? false
+            },
+
+            onExit() {
+              renderer.destroy()
+              wrapper.remove()
+            },
+          }
+        },
+
+        command({
+          editor,
+          range,
+          props: item,
+        }: {
+          editor: any
+          range: any
+          props: SectionHeading
+        }) {
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({
+              type: 'sectionRef',
+              attrs: { headingId: item.id, displayNum: item.displayNum },
+            })
+            .run()
+        },
+      },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ]
+  },
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import WriteView from "./views/WriteView.vue";
 import WorkbenchView from "./views/WorkbenchView.vue";
 import PdfView from "./views/PdfView.vue";
 import LibraryView from "./views/LibraryView.vue";
+import AnnotationsView from "./views/AnnotationsView.vue";
 import "./assets/style.css";
 import "./assets/editor.css";
 
@@ -16,6 +17,7 @@ const router = createRouter({
     { path: "/workbench", name: "workbench", component: WorkbenchView },
     { path: "/pdf", name: "pdf", component: PdfView },
     { path: "/library", name: "library", component: LibraryView },
+    { path: "/annotations", name: "annotations", component: AnnotationsView },
   ],
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import WriteView from "./views/WriteView.vue";
 import WorkbenchView from "./views/WorkbenchView.vue";
 import PdfView from "./views/PdfView.vue";
 import "./assets/style.css";
+import "./assets/editor.css";
 
 const router = createRouter({
   history: createWebHashHistory(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import App from "./App.vue";
 import WriteView from "./views/WriteView.vue";
 import WorkbenchView from "./views/WorkbenchView.vue";
 import PdfView from "./views/PdfView.vue";
+import LibraryView from "./views/LibraryView.vue";
 import "./assets/style.css";
 import "./assets/editor.css";
 
@@ -14,6 +15,7 @@ const router = createRouter({
     { path: "/write", name: "write", component: WriteView },
     { path: "/workbench", name: "workbench", component: WorkbenchView },
     { path: "/pdf", name: "pdf", component: PdfView },
+    { path: "/library", name: "library", component: LibraryView },
   ],
 });
 

--- a/src/views/AnnotationsView.vue
+++ b/src/views/AnnotationsView.vue
@@ -1,0 +1,574 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAllAnnotations, type AnnotationWithSource } from '../composables/useAnnotations'
+
+const router = useRouter()
+const { allAnnotations, allAnnotationsLoading, loadAll, deleteAndRefresh, updateNoteAndRefresh } = useAllAnnotations()
+
+onMounted(loadAll)
+
+// ── Search ────────────────────────────────────────────────────────────────────
+
+const searchTerm = ref('')
+const groupBySource = ref(true)
+
+const filtered = computed(() => {
+  const q = searchTerm.value.trim().toLowerCase()
+  if (!q) return allAnnotations.value
+  return allAnnotations.value.filter(a =>
+    (a.selectedText?.toLowerCase().includes(q)) ||
+    (a.noteText?.toLowerCase().includes(q)) ||
+    (a.itemTitle?.toLowerCase().includes(q)) ||
+    (a.itemAuthors?.toLowerCase().includes(q))
+  )
+})
+
+// ── Grouped view ──────────────────────────────────────────────────────────────
+
+interface Group {
+  key: string
+  label: string
+  sub: string
+  annotations: AnnotationWithSource[]
+}
+
+const groups = computed<Group[]>(() => {
+  const map = new Map<string, Group>()
+  for (const a of filtered.value) {
+    const k = String(a.itemId)
+    if (!map.has(k)) {
+      const authors = shortAuthors(a.itemAuthors)
+      map.set(k, {
+        key: k,
+        label: a.itemTitle ?? a.itemKey,
+        sub: [authors, a.itemYear].filter(Boolean).join(', '),
+        annotations: [],
+      })
+    }
+    map.get(k)!.annotations.push(a)
+  }
+  return [...map.values()]
+})
+
+// ── Note editing ──────────────────────────────────────────────────────────────
+
+const editingId = ref<number | null>(null)
+const editDraft = ref('')
+
+function startEdit(a: AnnotationWithSource) {
+  editingId.value = a.id
+  editDraft.value = a.noteText ?? ''
+}
+
+async function commitEdit(id: number) {
+  await updateNoteAndRefresh(id, editDraft.value)
+  editingId.value = null
+}
+
+function cancelEdit() {
+  editingId.value = null
+}
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+function openInPdf(a: AnnotationWithSource) {
+  router.push({
+    name: 'pdf',
+    query: { id: a.attachmentId, itemId: a.itemId, name: a.attachmentFileName, page: a.page },
+  })
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function shortAuthors(authors?: string): string {
+  if (!authors) return ''
+  const parts = authors.split(/[,;&]|and\s/i).map(s => s.trim()).filter(Boolean)
+  if (parts.length === 0) return ''
+  const last = parts[0].split(/\s+/).pop() ?? parts[0]
+  return parts.length > 2 ? `${last} et al.` : parts.length === 2
+    ? `${last} & ${(parts[1].split(/\s+/).pop() ?? parts[1])}`
+    : last
+}
+</script>
+
+<template>
+  <div class="ann-view">
+    <!-- Toolbar -->
+    <div class="ann-toolbar">
+      <div class="search-wrap">
+        <svg class="search-icon" width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+          <circle cx="5.5" cy="5.5" r="4"/>
+          <line x1="8.5" y1="8.5" x2="12" y2="12"/>
+        </svg>
+        <input
+          v-model="searchTerm"
+          class="search-input"
+          placeholder="Search annotations…"
+          spellcheck="false"
+        />
+        <button v-if="searchTerm" class="search-clear" @click="searchTerm = ''">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <line x1="1" y1="1" x2="9" y2="9"/><line x1="9" y1="1" x2="1" y2="9"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="toolbar-right">
+        <span class="ann-count">{{ filtered.length }} annotation{{ filtered.length !== 1 ? 's' : '' }}</span>
+        <button
+          class="group-toggle"
+          :class="{ active: groupBySource }"
+          title="Group by source"
+          @click="groupBySource = !groupBySource"
+        >
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+            <line x1="1" y1="3" x2="12" y2="3"/>
+            <line x1="3" y1="6.5" x2="12" y2="6.5"/>
+            <line x1="5" y1="10" x2="12" y2="10"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div v-if="allAnnotationsLoading" class="empty-state">
+      <span class="empty-label">Loading…</span>
+    </div>
+    <div v-else-if="filtered.length === 0" class="empty-state">
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+        <path d="M6 4h16a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2z"/>
+        <line x1="9" y1="10" x2="19" y2="10"/>
+        <line x1="9" y1="14" x2="15" y2="14"/>
+      </svg>
+      <span class="empty-label">{{ searchTerm ? 'No matches' : 'No annotations yet — highlight text in a PDF to create one' }}</span>
+    </div>
+
+    <!-- Grouped list -->
+    <div v-else-if="groupBySource" class="ann-list">
+      <div v-for="group in groups" :key="group.key" class="group">
+        <div class="group-header">
+          <span class="group-title">{{ group.label }}</span>
+          <span class="group-sub">{{ group.sub }}</span>
+          <span class="group-count">{{ group.annotations.length }}</span>
+        </div>
+        <div
+          v-for="a in group.annotations"
+          :key="a.id"
+          class="ann-row"
+        >
+          <div class="color-stripe" :style="{ background: a.color }"></div>
+          <div class="ann-body">
+            <div class="ann-text" @click="openInPdf(a)">
+              <span v-if="a.selectedText" class="ann-quote">"{{ a.selectedText }}"</span>
+              <span v-else class="ann-quote ann-quote--empty">(no text selected)</span>
+            </div>
+            <div class="ann-meta">
+              <span class="ann-page">p.&nbsp;{{ a.page }}</span>
+              <span class="meta-sep">·</span>
+              <span class="ann-file">{{ a.attachmentFileName }}</span>
+            </div>
+            <template v-if="editingId === a.id">
+              <textarea
+                v-model="editDraft"
+                class="note-edit"
+                rows="2"
+                placeholder="Add a note…"
+                @keydown.enter.ctrl="commitEdit(a.id)"
+                @keydown.escape="cancelEdit"
+              ></textarea>
+              <div class="note-edit-actions">
+                <button class="note-save" @click="commitEdit(a.id)">Save</button>
+                <button class="note-cancel" @click="cancelEdit">Cancel</button>
+              </div>
+            </template>
+            <div v-else-if="a.noteText" class="ann-note" @click="startEdit(a)">{{ a.noteText }}</div>
+            <button v-else class="note-add-btn" @click="startEdit(a)">+ note</button>
+          </div>
+          <div class="ann-actions">
+            <button class="action-btn" title="Open in PDF" @click="openInPdf(a)">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M2 2h8v8"/><path d="M2 10L10 2"/>
+              </svg>
+            </button>
+            <button class="action-btn action-del" title="Delete annotation" @click="deleteAndRefresh(a.id)">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M2 3h8M5 3V2h2v1M4 3v6.5a.5.5 0 00.5.5h3a.5.5 0 00.5-.5V3"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Flat list -->
+    <div v-else class="ann-list">
+      <div
+        v-for="a in filtered"
+        :key="a.id"
+        class="ann-row"
+      >
+        <div class="color-stripe" :style="{ background: a.color }"></div>
+        <div class="ann-body">
+          <div class="ann-text" @click="openInPdf(a)">
+            <span v-if="a.selectedText" class="ann-quote">"{{ a.selectedText }}"</span>
+            <span v-else class="ann-quote ann-quote--empty">(no text selected)</span>
+          </div>
+          <div class="ann-meta">
+            <span class="ann-source">{{ shortAuthors(a.itemAuthors) }}{{ a.itemYear ? ' ' + a.itemYear : '' }}</span>
+            <span class="meta-sep">·</span>
+            <span class="ann-page">p.&nbsp;{{ a.page }}</span>
+          </div>
+          <template v-if="editingId === a.id">
+            <textarea
+              v-model="editDraft"
+              class="note-edit"
+              rows="2"
+              placeholder="Add a note…"
+              @keydown.enter.ctrl="commitEdit(a.id)"
+              @keydown.escape="cancelEdit"
+            ></textarea>
+            <div class="note-edit-actions">
+              <button class="note-save" @click="commitEdit(a.id)">Save</button>
+              <button class="note-cancel" @click="cancelEdit">Cancel</button>
+            </div>
+          </template>
+          <div v-else-if="a.noteText" class="ann-note" @click="startEdit(a)">{{ a.noteText }}</div>
+          <button v-else class="note-add-btn" @click="startEdit(a)">+ note</button>
+        </div>
+        <div class="ann-actions">
+          <button class="action-btn" title="Open in PDF" @click="openInPdf(a)">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <path d="M2 2h8v8"/><path d="M2 10L10 2"/>
+            </svg>
+          </button>
+          <button class="action-btn action-del" title="Delete annotation" @click="deleteAndRefresh(a.id)">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <path d="M2 3h8M5 3V2h2v1M4 3v6.5a.5.5 0 00.5.5h3a.5.5 0 00.5-.5V3"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ann-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ── Toolbar ─────────────────────────────────────────────────────────────── */
+
+.ann-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-chrome);
+  flex-shrink: 0;
+}
+
+.search-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--surface-solid);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  padding: 0 9px;
+  height: 28px;
+}
+
+.search-icon {
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  font-size: 12.5px;
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+
+.search-input::placeholder { color: var(--text-tertiary); }
+
+.search-clear {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.ann-count {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.group-toggle {
+  background: none;
+  border: 1px solid transparent;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: background var(--t), border-color var(--t), color var(--t);
+}
+
+.group-toggle:hover { background: var(--bg-chrome-active); color: var(--text-secondary); }
+.group-toggle.active { background: var(--accent-soft); border-color: rgba(10,95,191,0.2); color: var(--accent); }
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-tertiary);
+  padding: 40px;
+  text-align: center;
+}
+
+.empty-label { font-size: 12.5px; max-width: 280px; line-height: 1.5; }
+
+/* ── List ────────────────────────────────────────────────────────────────── */
+
+.ann-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+/* ── Group header ────────────────────────────────────────────────────────── */
+
+.group-header {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 10px 16px 5px;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 1;
+}
+
+.group:not(:first-child) .group-header { border-top: 1px solid var(--border); }
+
+.group-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.group-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.group-count {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-chrome-active);
+  border-radius: 9px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}
+
+/* ── Row ─────────────────────────────────────────────────────────────────── */
+
+.ann-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  padding: 7px 14px 7px 0;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--t);
+}
+
+.ann-row:last-child { border-bottom: none; }
+.ann-row:hover { background: var(--bg-chrome); }
+
+.color-stripe {
+  width: 3px;
+  min-height: 100%;
+  align-self: stretch;
+  flex-shrink: 0;
+  margin-right: 11px;
+  border-radius: 0 2px 2px 0;
+  opacity: 0.7;
+}
+
+.ann-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.ann-text { cursor: pointer; }
+
+.ann-quote {
+  font-size: 12.5px;
+  color: var(--text);
+  font-family: var(--font-doc);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ann-quote--empty { color: var(--text-tertiary); font-style: italic; }
+
+.ann-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--text-tertiary);
+}
+
+.ann-source { font-weight: 500; color: var(--text-secondary); }
+.meta-sep { color: var(--border-medium); }
+.ann-page { font-variant-numeric: tabular-nums; }
+.ann-file { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
+
+.ann-note {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  font-style: italic;
+  line-height: 1.45;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.ann-note:hover { color: var(--text); }
+
+.note-add-btn {
+  background: none;
+  border: none;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 2px 0;
+  text-align: left;
+  opacity: 0;
+  transition: opacity var(--t), color var(--t);
+}
+
+.ann-row:hover .note-add-btn { opacity: 1; }
+.note-add-btn:hover { color: var(--accent); }
+
+.note-edit {
+  width: 100%;
+  font-size: 11.5px;
+  font-family: var(--font-ui);
+  color: var(--text);
+  background: var(--surface-solid);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  resize: none;
+  outline: none;
+  line-height: 1.45;
+}
+
+.note-edit:focus { border-color: var(--accent); }
+
+.note-edit-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.note-save, .note-cancel {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-medium);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  transition: background var(--t), border-color var(--t), color var(--t);
+}
+
+.note-save {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.note-save:hover { opacity: 0.9; }
+
+.note-cancel {
+  background: none;
+  color: var(--text-secondary);
+}
+
+.note-cancel:hover { background: var(--bg-chrome-active); }
+
+/* ── Row actions ─────────────────────────────────────────────────────────── */
+
+.ann-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--t);
+  padding-top: 1px;
+}
+
+.ann-row:hover .ann-actions { opacity: 1; }
+
+.action-btn {
+  background: none;
+  border: 1px solid transparent;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: background var(--t), border-color var(--t), color var(--t);
+}
+
+.action-btn:hover { background: var(--bg-chrome-active); color: var(--text-secondary); }
+.action-del:hover { background: #fff1f0; border-color: rgba(200,50,50,0.2); color: #c83232; }
+</style>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
-import { useLibrary, type LibraryItem, type ImportResult } from '../composables/useLibrary'
+import { useLibrary, type LibraryItem, type Attachment, type ImportResult } from '../composables/useLibrary'
 import LibraryEntryForm from '../components/LibraryEntryForm.vue'
 import CollectionsSidebar from '../components/CollectionsSidebar.vue'
+
+const router = useRouter()
 
 const {
   items, displayItems, loading, collections, tags, filterQuery,
@@ -11,6 +14,7 @@ const {
   deleteItem, createItem,
   addItemToCollection, removeItemFromCollection, getItemCollectionIds,
   importBibFile, exportBibFile,
+  pickAndAttachFile, getItemAttachments, removeAttachment, openAttachmentExternal,
 } = useLibrary()
 
 onMounted(() => {
@@ -169,16 +173,60 @@ const panelOpen = ref(false)
 const activeItemCollectionIds = ref<number[]>([])
 const addToCollId = ref<number | ''>('')
 
+// ── Attachments ───────────────────────────────────────────────────────────────
+
+const attachments = ref<Attachment[]>([])
+const attachingFile = ref(false)
+
+async function loadAttachments(itemId: number) {
+  attachments.value = await getItemAttachments(itemId)
+}
+
+async function attachFile() {
+  if (!activeItem.value) return
+  attachingFile.value = true
+  try {
+    const att = await pickAndAttachFile(activeItem.value.id)
+    if (att) attachments.value.push(att)
+  } finally {
+    attachingFile.value = false
+  }
+}
+
+async function deleteAttachment(id: number) {
+  await removeAttachment(id)
+  attachments.value = attachments.value.filter(a => a.id !== id)
+}
+
+function openInViewer(att: Attachment) {
+  router.push({
+    path: '/pdf',
+    query: {
+      id:     att.id.toString(),
+      itemId: (activeItem.value?.id ?? 0).toString(),
+      name:   att.fileName,
+    },
+  })
+}
+
+async function openExternal(id: number) {
+  await openAttachmentExternal(id)
+}
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
 async function openItem(item: LibraryItem) {
   activeItem.value = item
   panelOpen.value = true
   activeItemCollectionIds.value = await getItemCollectionIds(item.id)
+  await loadAttachments(item.id)
 }
 
 function closePanel() {
   panelOpen.value = false
   activeItem.value = null
   activeItemCollectionIds.value = []
+  attachments.value = []
 }
 
 watch(activeItem, async (item) => {
@@ -547,6 +595,31 @@ const countLabel = computed(() => {
             </div>
             <div v-if="activeItemCollections.length === 0 && collectionsForAdd.length === 0" class="dp-empty-hint">
               No collections
+            </div>
+          </div>
+
+          <!-- Files (attachments) -->
+          <div class="dp-block">
+            <div class="dp-block-label dp-files-header">
+              Files
+              <button class="dp-attach-btn" @click="attachFile" :disabled="attachingFile" title="Attach PDF">
+                <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+                  <line x1="5.5" y1="1" x2="5.5" y2="10"/>
+                  <line x1="1" y1="5.5" x2="10" y2="5.5"/>
+                </svg>
+              </button>
+            </div>
+            <div v-if="attachments.length === 0" class="dp-empty-hint">No files attached</div>
+            <div v-for="att in attachments" :key="att.id" class="dp-file-row">
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="dp-file-icon">
+                <rect x="1.5" y="0.5" width="8" height="10" rx="1"/>
+                <line x1="3.5" y1="4" x2="7.5" y2="4"/>
+                <line x1="3.5" y1="6" x2="7.5" y2="6"/>
+                <line x1="3.5" y1="8" x2="5.5" y2="8"/>
+              </svg>
+              <span class="dp-file-name" @click="openInViewer(att)" title="Open in Quire viewer">{{ att.fileName }}</span>
+              <button class="dp-file-ext" @click="openExternal(att.id)" title="Open in system PDF reader">↗</button>
+              <button class="dp-file-del" @click="deleteAttachment(att.id)" title="Remove attachment">×</button>
             </div>
           </div>
 
@@ -1395,4 +1468,67 @@ const countLabel = computed(() => {
   transform: translateX(100%);
   opacity: 0;
 }
+
+/* ── Files / Attachments ──────────────────────────────────────────────────── */
+
+.dp-files-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dp-attach-btn {
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: 4px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--text-secondary);
+  padding: 0;
+  transition: background var(--t);
+}
+.dp-attach-btn:hover:not(:disabled) { background: var(--bg-chrome); }
+.dp-attach-btn:disabled { opacity: 0.4; cursor: default; }
+
+.dp-file-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+}
+.dp-file-row:last-child { border-bottom: none; }
+
+.dp-file-icon { color: var(--text-tertiary); flex-shrink: 0; }
+
+.dp-file-name {
+  flex: 1;
+  font-size: 11.5px;
+  color: var(--accent);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.dp-file-name:hover { text-decoration: underline; }
+
+.dp-file-ext,
+.dp-file-del {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color var(--t);
+}
+.dp-file-ext:hover { color: var(--accent); }
+.dp-file-del:hover { color: #E8650A; }
 </style>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
-import { useLibrary, type LibraryItem } from '../composables/useLibrary'
+import { invoke } from '@tauri-apps/api/core'
+import { useLibrary, type LibraryItem, type ImportResult } from '../composables/useLibrary'
 import LibraryEntryForm from '../components/LibraryEntryForm.vue'
 import CollectionsSidebar from '../components/CollectionsSidebar.vue'
 
@@ -9,6 +10,7 @@ const {
   loadItems, loadCollections, loadTags, applyFilter,
   deleteItem, createItem,
   addItemToCollection, removeItemFromCollection, getItemCollectionIds,
+  importBibFile, exportBibFile,
 } = useLibrary()
 
 onMounted(() => {
@@ -102,6 +104,62 @@ function clearFilters() {
     tagName: filterQuery.value.tagName,
   }
   applyFilter()
+}
+
+// ── Import ────────────────────────────────────────────────────────────────────
+
+const importOpen       = ref(false)
+const importFilePath   = ref('')
+const importMode       = ref<'merge' | 'replace'>('merge')
+const importing        = ref(false)
+const importResult     = ref<ImportResult | null>(null)
+const importError      = ref('')
+
+async function pickImportFile() {
+  const p = await invoke<string | null>('pick_import_bib')
+  if (p) {
+    importFilePath.value = p
+    importResult.value = null
+    importError.value = ''
+  }
+}
+
+async function doImport() {
+  if (!importFilePath.value) return
+  importing.value = true
+  importError.value = ''
+  try {
+    importResult.value = await importBibFile(importFilePath.value, importMode.value)
+  } catch (e) {
+    importError.value = String(e)
+  } finally {
+    importing.value = false
+  }
+}
+
+function closeImport() {
+  importOpen.value  = false
+  importFilePath.value = ''
+  importResult.value = null
+  importError.value = ''
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+const exportingAll = ref(false)
+
+async function doExport() {
+  const p = await invoke<string | null>('pick_export_bib')
+  if (!p) return
+  exportingAll.value = true
+  try {
+    const ids = hasActiveFilter.value || filterQuery.value.collectionId || filterQuery.value.tagName
+      ? displayItems.value.map(i => i.id)
+      : []
+    await exportBibFile(ids, p)
+  } finally {
+    exportingAll.value = false
+  }
 }
 
 // ── Detail panel ──────────────────────────────────────────────────────────────
@@ -261,6 +319,20 @@ const countLabel = computed(() => {
               </svg>
             </button>
           </div>
+          <button class="toolbar-btn" @click="importOpen = true" title="Import .bib file">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 1v7M3 5l3 3 3-3"/>
+              <path d="M2 10h8"/>
+            </svg>
+            Import
+          </button>
+          <button class="toolbar-btn" @click="doExport" :disabled="exportingAll" title="Export .bib file">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M6 8V1M3 4l3-3 3 3"/>
+              <path d="M2 10h8"/>
+            </svg>
+            Export
+          </button>
           <button class="add-btn" @click="openAddForm" title="Add entry">
             <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
               <line x1="5.5" y1="1" x2="5.5" y2="10"/>
@@ -522,6 +594,51 @@ const countLabel = computed(() => {
     @saved="onFormSaved"
   />
 
+  <!-- Import modal -->
+  <Teleport to="body">
+    <div class="confirm-backdrop" v-if="importOpen" @click.self="closeImport">
+      <div class="confirm-dialog import-dialog">
+        <p class="confirm-msg">Import .bib file</p>
+
+        <div class="import-file-row">
+          <span class="import-path">{{ importFilePath || 'No file selected' }}</span>
+          <button class="fs-btn secondary" @click="pickImportFile">Browse…</button>
+        </div>
+
+        <div class="import-mode">
+          <label class="mode-label">
+            <input type="radio" v-model="importMode" value="merge" />
+            <span>Merge — skip entries with duplicate keys</span>
+          </label>
+          <label class="mode-label">
+            <input type="radio" v-model="importMode" value="replace" />
+            <span>Replace — overwrite existing entries by key</span>
+          </label>
+        </div>
+
+        <div class="import-result" v-if="importResult">
+          <span class="result-added">{{ importResult.added }} added</span>
+          <span class="result-skipped" v-if="importResult.skipped > 0">· {{ importResult.skipped }} skipped</span>
+          <span class="result-errors"  v-if="importResult.errors.length > 0">· {{ importResult.errors.length }} errors</span>
+        </div>
+
+        <p class="fetch-error" v-if="importError" style="margin:8px 0 0">{{ importError }}</p>
+
+        <div class="confirm-actions" style="margin-top:16px">
+          <button class="fs-btn secondary" @click="closeImport">
+            {{ importResult ? 'Done' : 'Cancel' }}
+          </button>
+          <button
+            class="fs-btn primary"
+            :disabled="!importFilePath || importing"
+            @click="doImport"
+            v-if="!importResult"
+          >{{ importing ? 'Importing…' : 'Import' }}</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+
   <!-- Delete confirmation -->
   <Teleport to="body">
     <div class="confirm-backdrop" v-if="confirmingDelete" @click.self="confirmingDelete = null">
@@ -636,6 +753,25 @@ const countLabel = computed(() => {
   transition: color var(--t);
 }
 .search-clear:hover { color: var(--text); }
+
+.toolbar-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px;
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background var(--t), color var(--t);
+}
+.toolbar-btn:hover:not(:disabled) { background: var(--bg-chrome-active); color: var(--text); }
+.toolbar-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .add-btn {
   flex-shrink: 0;
@@ -1179,6 +1315,74 @@ const countLabel = computed(() => {
 .fs-btn.secondary:hover { opacity: 0.8; }
 .fs-btn.danger { background: #C0392B; color: #fff; }
 .fs-btn.danger:hover { opacity: 0.88; }
+.fs-btn.primary { background: var(--accent); color: #fff; }
+.fs-btn.primary:hover { opacity: 0.88; }
+.fs-btn.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Import dialog ──────────────────────────────────────────────────────────── */
+
+.import-dialog {
+  max-width: 420px;
+}
+
+.import-file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 12px;
+}
+
+.import-path {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: var(--bg-chrome);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  min-width: 0;
+}
+
+.import-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.mode-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.mode-label input[type="radio"] {
+  accent-color: var(--accent);
+}
+
+.import-result {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  background: #16963F18;
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.result-added   { color: #16963F; }
+.result-skipped { color: var(--text-secondary); }
+.result-errors  { color: var(--accent-orange); }
+
+.fetch-error { font-size: 11.5px; color: var(--accent-orange); }
 
 /* ── Transition ────────────────────────────────────────────────────────────── */
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useLibrary, type LibraryItem } from '../composables/useLibrary'
+import LibraryEntryForm from '../components/LibraryEntryForm.vue'
 
-const { items, loading, loadItems } = useLibrary()
+const { items, loading, loadItems, deleteItem, createItem } = useLibrary()
 
 onMounted(loadItems)
 
@@ -46,6 +47,50 @@ function closePanel() {
   activeItem.value = null
 }
 
+// ── Form (add / edit) ─────────────────────────────────────────────────────────
+
+const formOpen = ref(false)
+const formEditItem = ref<LibraryItem | null>(null)
+
+function openAddForm() {
+  formEditItem.value = null
+  formOpen.value = true
+}
+
+function openEditForm(item: LibraryItem) {
+  formEditItem.value = item
+  formOpen.value = true
+}
+
+function onFormSaved(saved: LibraryItem) {
+  formOpen.value = false
+  // If we were editing the active item, refresh it in the panel
+  if (activeItem.value?.id === saved.id) {
+    activeItem.value = saved
+  }
+}
+
+async function duplicateItem(item: LibraryItem) {
+  const { id: _id, addedAt: _a, updatedAt: _u, tags: _t, ...fields } = item
+  await createItem({ ...fields, key: `${item.key}_copy` })
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+const confirmingDelete = ref<LibraryItem | null>(null)
+
+function requestDelete(item: LibraryItem) {
+  confirmingDelete.value = item
+}
+
+async function confirmDelete() {
+  if (!confirmingDelete.value) return
+  const id = confirmingDelete.value.id
+  await deleteItem(id)
+  if (activeItem.value?.id === id) closePanel()
+  confirmingDelete.value = null
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TYPE_COLORS: Record<string, string> = {
@@ -85,6 +130,13 @@ function venue(item: LibraryItem): string {
         <h2 class="lib-title">Library</h2>
         <span class="lib-count" v-if="!loading">{{ items.length }} item{{ items.length !== 1 ? 's' : '' }}</span>
         <span class="lib-count loading" v-else>Loading…</span>
+        <button class="add-btn" @click="openAddForm" title="Add entry">
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <line x1="6.5" y1="1" x2="6.5" y2="12"/>
+            <line x1="1" y1="6.5" x2="12" y2="6.5"/>
+          </svg>
+          Add
+        </button>
       </div>
 
       <div class="lib-table-wrap">
@@ -215,9 +267,53 @@ function venue(item: LibraryItem): string {
             <p class="dp-keywords">{{ activeItem.keywords }}</p>
           </div>
         </div>
+
+        <div class="dp-actions">
+          <button class="dp-action-btn" @click="openEditForm(activeItem)" title="Edit entry">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M9 1.5L11.5 4L5 10.5H2.5V8L9 1.5Z"/>
+            </svg>
+            Edit
+          </button>
+          <button class="dp-action-btn" @click="duplicateItem(activeItem)" title="Duplicate entry">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="4.5" y="4.5" width="7" height="7" rx="1"/>
+              <path d="M4.5 8.5H2.5a1 1 0 01-1-1v-5a1 1 0 011-1h5a1 1 0 011 1v2"/>
+            </svg>
+            Duplicate
+          </button>
+          <button class="dp-action-btn danger" @click="requestDelete(activeItem)" title="Delete entry">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 3.5h9M5 3.5V2h3v1.5M5.5 5.5v4M7.5 5.5v4M3 3.5l.5 7h6l.5-7"/>
+            </svg>
+            Delete
+          </button>
+        </div>
       </div>
     </Transition>
   </div>
+
+  <!-- Entry form modal -->
+  <LibraryEntryForm
+    v-if="formOpen"
+    :edit-item="formEditItem"
+    @close="formOpen = false"
+    @saved="onFormSaved"
+  />
+
+  <!-- Delete confirmation -->
+  <Teleport to="body">
+    <div class="confirm-backdrop" v-if="confirmingDelete" @click.self="confirmingDelete = null">
+      <div class="confirm-dialog">
+        <p class="confirm-msg">Delete <strong>{{ confirmingDelete.key }}</strong>?</p>
+        <p class="confirm-sub">This will remove the entry from your library and cannot be undone.</p>
+        <div class="confirm-actions">
+          <button class="fs-btn secondary" @click="confirmingDelete = null">Cancel</button>
+          <button class="fs-btn danger" @click="confirmDelete">Delete</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>
@@ -240,12 +336,30 @@ function venue(item: LibraryItem): string {
 
 .lib-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 10px;
-  padding: 18px 24px 12px;
+  padding: 12px 20px 12px 24px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
+
+.add-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity var(--t);
+}
+.add-btn:hover { opacity: 0.88; }
 
 .lib-title {
   font-size: 15px;
@@ -535,6 +649,109 @@ function venue(item: LibraryItem): string {
   color: var(--text-secondary);
   line-height: 1.5;
 }
+
+/* ── Detail panel actions ──────────────────────────────────────────────────── */
+
+.dp-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.dp-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--t), color var(--t);
+  text-align: left;
+}
+
+.dp-action-btn:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+.dp-action-btn.danger { color: #C0392B; }
+.dp-action-btn.danger:hover { background: rgba(192, 57, 43, 0.08); }
+
+/* ── Confirm dialog ────────────────────────────────────────────────────────── */
+
+.confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-dialog {
+  background: var(--surface-solid);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 22px 24px 18px;
+  max-width: 340px;
+  width: 100%;
+}
+
+.confirm-msg {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.confirm-sub {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 18px;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.fs-btn {
+  height: 32px;
+  padding: 0 16px;
+  border-radius: var(--radius);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  font-family: var(--font-ui);
+  transition: opacity var(--t), background var(--t);
+}
+
+.fs-btn.secondary {
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
+}
+.fs-btn.secondary:hover { opacity: 0.8; }
+
+.fs-btn.danger {
+  background: #C0392B;
+  color: #fff;
+}
+.fs-btn.danger:hover { opacity: 0.88; }
 
 /* ── Transition ────────────────────────────────────────────────────────────── */
 

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,0 +1,550 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useLibrary, type LibraryItem } from '../composables/useLibrary'
+
+const { items, loading, loadItems } = useLibrary()
+
+onMounted(loadItems)
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+type SortKey = 'title' | 'authors' | 'year' | 'entryType'
+const sortKey = ref<SortKey>('title')
+const sortAsc = ref(true)
+
+function setSort(key: SortKey) {
+  if (sortKey.value === key) {
+    sortAsc.value = !sortAsc.value
+  } else {
+    sortKey.value = key
+    sortAsc.value = true
+  }
+}
+
+const sorted = computed(() => {
+  const list = [...items.value]
+  list.sort((a, b) => {
+    const av = (a[sortKey.value] ?? '').toLowerCase()
+    const bv = (b[sortKey.value] ?? '').toLowerCase()
+    return sortAsc.value ? av.localeCompare(bv) : bv.localeCompare(av)
+  })
+  return list
+})
+
+// ── Detail panel ──────────────────────────────────────────────────────────────
+
+const activeItem = ref<LibraryItem | null>(null)
+const panelOpen = ref(false)
+
+function openItem(item: LibraryItem) {
+  activeItem.value = item
+  panelOpen.value = true
+}
+
+function closePanel() {
+  panelOpen.value = false
+  activeItem.value = null
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const TYPE_COLORS: Record<string, string> = {
+  article:      '#0A5FBF',
+  techreport:   '#E8650A',
+  book:         '#7C3AED',
+  inproceedings:'#16963F',
+  misc:         '#A5A4A2',
+}
+
+function typeColor(entryType: string): string {
+  return TYPE_COLORS[entryType] ?? TYPE_COLORS.misc
+}
+
+function typeLabel(entryType: string): string {
+  const map: Record<string, string> = {
+    article:       'art',
+    techreport:    'rep',
+    book:          'bk',
+    inproceedings: 'conf',
+    misc:          'misc',
+  }
+  return map[entryType] ?? entryType.slice(0, 4)
+}
+
+function venue(item: LibraryItem): string {
+  return item.journal ?? item.booktitle ?? item.publisher ?? item.institution ?? ''
+}
+</script>
+
+<template>
+  <div class="lib-layout">
+
+    <!-- ── Main list ─────────────────────────────────────────────────────────── -->
+    <div class="lib-main">
+      <div class="lib-header">
+        <h2 class="lib-title">Library</h2>
+        <span class="lib-count" v-if="!loading">{{ items.length }} item{{ items.length !== 1 ? 's' : '' }}</span>
+        <span class="lib-count loading" v-else>Loading…</span>
+      </div>
+
+      <div class="lib-table-wrap">
+        <table class="lib-table" v-if="sorted.length > 0">
+          <thead>
+            <tr>
+              <th class="col-type">Type</th>
+              <th
+                class="col-title sortable"
+                :class="{ sorted: sortKey === 'title' }"
+                @click="setSort('title')"
+              >
+                Title
+                <span class="sort-icon">{{ sortKey === 'title' ? (sortAsc ? '↑' : '↓') : '' }}</span>
+              </th>
+              <th
+                class="col-authors sortable"
+                :class="{ sorted: sortKey === 'authors' }"
+                @click="setSort('authors')"
+              >
+                Authors
+                <span class="sort-icon">{{ sortKey === 'authors' ? (sortAsc ? '↑' : '↓') : '' }}</span>
+              </th>
+              <th
+                class="col-year sortable"
+                :class="{ sorted: sortKey === 'year' }"
+                @click="setSort('year')"
+              >
+                Year
+                <span class="sort-icon">{{ sortKey === 'year' ? (sortAsc ? '↑' : '↓') : '' }}</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="item in sorted"
+              :key="item.id"
+              class="lib-row"
+              :class="{ active: activeItem?.id === item.id }"
+              @click="openItem(item)"
+            >
+              <td class="col-type">
+                <span
+                  class="type-badge"
+                  :style="{ background: typeColor(item.entryType) + '18', color: typeColor(item.entryType) }"
+                >{{ typeLabel(item.entryType) }}</span>
+              </td>
+              <td class="col-title">
+                <span class="row-title">{{ item.title ?? item.key }}</span>
+              </td>
+              <td class="col-authors">{{ item.authors ?? '—' }}</td>
+              <td class="col-year">{{ item.year ?? '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="lib-empty" v-else-if="!loading">
+          <p>No items in library.</p>
+          <p class="lib-empty-sub">Add references via the Library menu, or import a .bib file.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Detail panel ──────────────────────────────────────────────────────── -->
+    <Transition name="panel">
+      <div class="detail-panel" v-if="panelOpen && activeItem">
+        <div class="dp-header">
+          <span class="dp-label">Source Detail</span>
+          <button class="dp-close" @click="closePanel" title="Close">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+              <line x1="1" y1="1" x2="12" y2="12"/>
+              <line x1="12" y1="1" x2="1" y2="12"/>
+            </svg>
+          </button>
+        </div>
+
+        <div class="dp-body">
+          <div class="dp-type-row">
+            <span
+              class="type-badge"
+              :style="{ background: typeColor(activeItem.entryType) + '18', color: typeColor(activeItem.entryType) }"
+            >{{ typeLabel(activeItem.entryType) }}</span>
+            <span class="dp-key">{{ activeItem.key }}</span>
+          </div>
+
+          <p class="dp-title">{{ activeItem.title }}</p>
+
+          <div class="dp-meta">
+            <span class="dp-authors" v-if="activeItem.authors">{{ activeItem.authors }}</span>
+            <span class="dp-venue" v-if="venue(activeItem) || activeItem.year">
+              {{ venue(activeItem) }}<template v-if="venue(activeItem) && activeItem.year"> · </template>{{ activeItem.year }}
+            </span>
+            <a
+              v-if="activeItem.doi"
+              class="dp-doi"
+              :href="`https://doi.org/${activeItem.doi}`"
+              target="_blank"
+              rel="noopener"
+            >{{ activeItem.doi }}</a>
+          </div>
+
+          <div class="dp-fields" v-if="activeItem.volume || activeItem.pages || activeItem.number || activeItem.isbn">
+            <div class="dp-field" v-if="activeItem.volume">
+              <span class="dp-field-label">Vol</span>
+              <span>{{ activeItem.volume }}</span>
+            </div>
+            <div class="dp-field" v-if="activeItem.number">
+              <span class="dp-field-label">No.</span>
+              <span>{{ activeItem.number }}</span>
+            </div>
+            <div class="dp-field" v-if="activeItem.pages">
+              <span class="dp-field-label">Pp.</span>
+              <span>{{ activeItem.pages }}</span>
+            </div>
+            <div class="dp-field" v-if="activeItem.isbn">
+              <span class="dp-field-label">ISBN</span>
+              <span>{{ activeItem.isbn }}</span>
+            </div>
+          </div>
+
+          <div class="dp-block" v-if="activeItem.abstractText">
+            <div class="dp-block-label">Abstract</div>
+            <p class="dp-abstract">{{ activeItem.abstractText }}</p>
+          </div>
+
+          <div class="dp-block" v-if="activeItem.keywords">
+            <div class="dp-block-label">Keywords</div>
+            <p class="dp-keywords">{{ activeItem.keywords }}</p>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.lib-layout {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ── Main list ─────────────────────────────────────────────────────────────── */
+
+.lib-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.lib-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 18px 24px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.lib-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.lib-count {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.lib-count.loading {
+  font-style: italic;
+}
+
+.lib-table-wrap {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.lib-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.lib-table thead tr {
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-chrome);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.lib-table th {
+  padding: 8px 12px 8px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-tertiary);
+  text-align: left;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.lib-table th.sortable {
+  cursor: pointer;
+}
+
+.lib-table th.sortable:hover {
+  color: var(--text-secondary);
+}
+
+.lib-table th.sorted {
+  color: var(--accent);
+}
+
+.sort-icon {
+  margin-left: 3px;
+  font-size: 10px;
+}
+
+.lib-row {
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background var(--t);
+}
+
+.lib-row:hover {
+  background: var(--bg-chrome);
+}
+
+.lib-row.active {
+  background: var(--accent-soft);
+}
+
+.lib-table td {
+  padding: 10px 12px;
+  vertical-align: middle;
+}
+
+.col-type {
+  width: 52px;
+}
+
+.col-authors {
+  width: 200px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.col-year {
+  width: 60px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  padding-right: 20px;
+}
+
+.row-title {
+  font-weight: 500;
+  color: var(--text);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.4;
+}
+
+.type-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  white-space: nowrap;
+}
+
+.lib-empty {
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.lib-empty-sub {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+/* ── Detail panel ──────────────────────────────────────────────────────────── */
+
+.detail-panel {
+  width: 284px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+  background: var(--surface-solid);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.dp-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-tertiary);
+}
+
+.dp-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  transition: background var(--t), color var(--t);
+}
+.dp-close:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text);
+}
+
+.dp-body {
+  padding: 16px 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dp-type-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dp-key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.dp-title {
+  font-family: var(--font-doc);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.dp-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dp-authors {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.dp-venue {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.dp-doi {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  text-decoration: none;
+  word-break: break-all;
+}
+.dp-doi:hover { text-decoration: underline; }
+
+.dp-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+.dp-field {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 11.5px;
+}
+
+.dp-field-label {
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-tertiary);
+}
+
+.dp-block {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.dp-block-label {
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-tertiary);
+}
+
+.dp-abstract {
+  font-family: var(--font-doc);
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+.dp-keywords {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ── Transition ────────────────────────────────────────────────────────────── */
+
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform var(--t), opacity var(--t);
+}
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+</style>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,11 +1,29 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useLibrary, type LibraryItem } from '../composables/useLibrary'
 import LibraryEntryForm from '../components/LibraryEntryForm.vue'
+import CollectionsSidebar from '../components/CollectionsSidebar.vue'
 
-const { items, loading, loadItems, deleteItem, createItem } = useLibrary()
+const {
+  items, displayItems, loading, collections, tags, filterQuery,
+  loadItems, loadCollections, loadTags, applyFilter,
+  deleteItem, createItem,
+  addItemToCollection, removeItemFromCollection, getItemCollectionIds,
+} = useLibrary()
 
-onMounted(loadItems)
+onMounted(() => {
+  loadItems()
+  loadCollections()
+  loadTags()
+})
+
+// ── Tag color lookup ──────────────────────────────────────────────────────────
+
+const tagColorMap = computed(() => {
+  const map = new Map<string, string>()
+  for (const t of tags.value) map.set(t.name, t.color)
+  return map
+})
 
 // ── Sorting ───────────────────────────────────────────────────────────────────
 
@@ -23,7 +41,7 @@ function setSort(key: SortKey) {
 }
 
 const sorted = computed(() => {
-  const list = [...items.value]
+  const list = [...displayItems.value]
   list.sort((a, b) => {
     const av = (a[sortKey.value] ?? '').toLowerCase()
     const bv = (b[sortKey.value] ?? '').toLowerCase()
@@ -32,19 +50,103 @@ const sorted = computed(() => {
   return list
 })
 
+// ── Search + filter (F6) ──────────────────────────────────────────────────────
+
+const searchText = ref('')
+const yearMin = ref('')
+const yearMax = ref('')
+
+const TYPE_OPTIONS = ['article', 'book', 'inproceedings', 'techreport', 'misc'] as const
+const selectedTypes = ref<string[]>([])
+
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleFilter() {
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    filterQuery.value = {
+      ...filterQuery.value,
+      text: searchText.value || undefined,
+      entryTypes: selectedTypes.value.length ? selectedTypes.value : undefined,
+      yearMin: yearMin.value || undefined,
+      yearMax: yearMax.value || undefined,
+    }
+    applyFilter()
+  }, 200)
+}
+
+function toggleType(t: string) {
+  const idx = selectedTypes.value.indexOf(t)
+  if (idx === -1) selectedTypes.value = [...selectedTypes.value, t]
+  else selectedTypes.value = selectedTypes.value.filter(x => x !== t)
+  scheduleFilter()
+}
+
+function toggleDoi() {
+  filterQuery.value = { ...filterQuery.value, hasDoi: filterQuery.value.hasDoi ? undefined : true }
+  applyFilter()
+}
+
+const hasActiveFilter = computed(() =>
+  !!searchText.value || selectedTypes.value.length > 0 ||
+  !!yearMin.value || !!yearMax.value || !!filterQuery.value.hasDoi
+)
+
+function clearFilters() {
+  searchText.value = ''
+  yearMin.value = ''
+  yearMax.value = ''
+  selectedTypes.value = []
+  filterQuery.value = {
+    collectionId: filterQuery.value.collectionId,
+    tagName: filterQuery.value.tagName,
+  }
+  applyFilter()
+}
+
 // ── Detail panel ──────────────────────────────────────────────────────────────
 
 const activeItem = ref<LibraryItem | null>(null)
 const panelOpen = ref(false)
+const activeItemCollectionIds = ref<number[]>([])
+const addToCollId = ref<number | ''>('')
 
-function openItem(item: LibraryItem) {
+async function openItem(item: LibraryItem) {
   activeItem.value = item
   panelOpen.value = true
+  activeItemCollectionIds.value = await getItemCollectionIds(item.id)
 }
 
 function closePanel() {
   panelOpen.value = false
   activeItem.value = null
+  activeItemCollectionIds.value = []
+}
+
+watch(activeItem, async (item) => {
+  if (!item) { activeItemCollectionIds.value = []; return }
+  activeItemCollectionIds.value = await getItemCollectionIds(item.id)
+})
+
+const activeItemCollections = computed(() =>
+  collections.value.filter(c => activeItemCollectionIds.value.includes(c.id))
+)
+
+const collectionsForAdd = computed(() =>
+  collections.value.filter(c => !activeItemCollectionIds.value.includes(c.id))
+)
+
+async function addToCol() {
+  if (!activeItem.value || !addToCollId.value) return
+  await addItemToCollection(Number(addToCollId.value), activeItem.value.id)
+  activeItemCollectionIds.value = await getItemCollectionIds(activeItem.value.id)
+  addToCollId.value = ''
+}
+
+async function removeFromCol(collId: number) {
+  if (!activeItem.value) return
+  await removeItemFromCollection(collId, activeItem.value.id)
+  activeItemCollectionIds.value = await getItemCollectionIds(activeItem.value.id)
 }
 
 // ── Form (add / edit) ─────────────────────────────────────────────────────────
@@ -64,7 +166,6 @@ function openEditForm(item: LibraryItem) {
 
 function onFormSaved(saved: LibraryItem) {
   formOpen.value = false
-  // If we were editing the active item, refresh it in the panel
   if (activeItem.value?.id === saved.id) {
     activeItem.value = saved
   }
@@ -94,11 +195,11 @@ async function confirmDelete() {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TYPE_COLORS: Record<string, string> = {
-  article:      '#0A5FBF',
-  techreport:   '#E8650A',
-  book:         '#7C3AED',
-  inproceedings:'#16963F',
-  misc:         '#A5A4A2',
+  article:       '#0A5FBF',
+  techreport:    '#E8650A',
+  book:          '#7C3AED',
+  inproceedings: '#16963F',
+  misc:          '#A5A4A2',
 }
 
 function typeColor(entryType: string): string {
@@ -119,24 +220,97 @@ function typeLabel(entryType: string): string {
 function venue(item: LibraryItem): string {
   return item.journal ?? item.booktitle ?? item.publisher ?? item.institution ?? ''
 }
+
+const countLabel = computed(() => {
+  const d = displayItems.value.length
+  const t = items.value.length
+  if (d === t) return `${t} item${t !== 1 ? 's' : ''}`
+  return `${d} of ${t}`
+})
 </script>
 
 <template>
   <div class="lib-layout">
 
+    <!-- ── Left sidebar ─────────────────────────────────────────────────────── -->
+    <CollectionsSidebar />
+
     <!-- ── Main list ─────────────────────────────────────────────────────────── -->
     <div class="lib-main">
       <div class="lib-header">
-        <h2 class="lib-title">Library</h2>
-        <span class="lib-count" v-if="!loading">{{ items.length }} item{{ items.length !== 1 ? 's' : '' }}</span>
-        <span class="lib-count loading" v-else>Loading…</span>
-        <button class="add-btn" @click="openAddForm" title="Add entry">
-          <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <line x1="6.5" y1="1" x2="6.5" y2="12"/>
-            <line x1="1" y1="6.5" x2="12" y2="6.5"/>
-          </svg>
-          Add
-        </button>
+        <div class="lib-header-top">
+          <h2 class="lib-title">Library</h2>
+          <span class="lib-count" :class="{ loading }">
+            {{ loading ? 'Loading…' : countLabel }}
+          </span>
+          <div class="lib-search-wrap">
+            <svg class="search-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+              <circle cx="5" cy="5" r="3.5"/>
+              <line x1="7.8" y1="7.8" x2="11" y2="11"/>
+            </svg>
+            <input
+              v-model="searchText"
+              class="lib-search"
+              placeholder="Search entries…"
+              @input="scheduleFilter"
+            />
+            <button v-if="searchText" class="search-clear" @click="searchText = ''; scheduleFilter()">
+              <svg width="9" height="9" viewBox="0 0 9 9" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+                <line x1="1" y1="1" x2="8" y2="8"/>
+                <line x1="8" y1="1" x2="1" y2="8"/>
+              </svg>
+            </button>
+          </div>
+          <button class="add-btn" @click="openAddForm" title="Add entry">
+            <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <line x1="5.5" y1="1" x2="5.5" y2="10"/>
+              <line x1="1" y1="5.5" x2="10" y2="5.5"/>
+            </svg>
+            Add
+          </button>
+        </div>
+
+        <div class="lib-filter-bar">
+          <button
+            v-for="t in TYPE_OPTIONS"
+            :key="t"
+            class="filter-pill"
+            :class="{ active: selectedTypes.includes(t) }"
+            :style="selectedTypes.includes(t) ? { background: typeColor(t) + '18', color: typeColor(t), borderColor: typeColor(t) + '60' } : {}"
+            @click="toggleType(t)"
+          >{{ typeLabel(t) }}</button>
+
+          <span class="filter-sep"></span>
+
+          <div class="year-range">
+            <input
+              v-model="yearMin"
+              class="year-input"
+              placeholder="From"
+              maxlength="4"
+              @input="scheduleFilter"
+            />
+            <span class="year-dash">–</span>
+            <input
+              v-model="yearMax"
+              class="year-input"
+              placeholder="To"
+              maxlength="4"
+              @input="scheduleFilter"
+            />
+          </div>
+
+          <button
+            class="filter-pill"
+            :class="{ active: !!filterQuery.hasDoi }"
+            :style="filterQuery.hasDoi ? { background: '#16963F18', color: '#16963F', borderColor: '#16963F60' } : {}"
+            @click="toggleDoi"
+          >Has DOI</button>
+
+          <button v-if="hasActiveFilter" class="filter-clear-btn" @click="clearFilters">
+            Clear filters
+          </button>
+        </div>
       </div>
 
       <div class="lib-table-wrap">
@@ -148,26 +322,17 @@ function venue(item: LibraryItem): string {
                 class="col-title sortable"
                 :class="{ sorted: sortKey === 'title' }"
                 @click="setSort('title')"
-              >
-                Title
-                <span class="sort-icon">{{ sortKey === 'title' ? (sortAsc ? '↑' : '↓') : '' }}</span>
-              </th>
+              >Title <span class="sort-icon">{{ sortKey === 'title' ? (sortAsc ? '↑' : '↓') : '' }}</span></th>
               <th
                 class="col-authors sortable"
                 :class="{ sorted: sortKey === 'authors' }"
                 @click="setSort('authors')"
-              >
-                Authors
-                <span class="sort-icon">{{ sortKey === 'authors' ? (sortAsc ? '↑' : '↓') : '' }}</span>
-              </th>
+              >Authors <span class="sort-icon">{{ sortKey === 'authors' ? (sortAsc ? '↑' : '↓') : '' }}</span></th>
               <th
                 class="col-year sortable"
                 :class="{ sorted: sortKey === 'year' }"
                 @click="setSort('year')"
-              >
-                Year
-                <span class="sort-icon">{{ sortKey === 'year' ? (sortAsc ? '↑' : '↓') : '' }}</span>
-              </th>
+              >Year <span class="sort-icon">{{ sortKey === 'year' ? (sortAsc ? '↑' : '↓') : '' }}</span></th>
             </tr>
           </thead>
           <tbody>
@@ -186,6 +351,18 @@ function venue(item: LibraryItem): string {
               </td>
               <td class="col-title">
                 <span class="row-title">{{ item.title ?? item.key }}</span>
+                <div class="row-tags" v-if="item.tags && item.tags.length > 0">
+                  <span
+                    v-for="tagName in item.tags"
+                    :key="tagName"
+                    class="row-tag-chip"
+                    :style="{
+                      background: (tagColorMap.get(tagName) ?? '#A5A4A2') + '22',
+                      color: tagColorMap.get(tagName) ?? '#A5A4A2',
+                      borderColor: (tagColorMap.get(tagName) ?? '#A5A4A2') + '55',
+                    }"
+                  >{{ tagName }}</span>
+                </div>
               </td>
               <td class="col-authors">{{ item.authors ?? '—' }}</td>
               <td class="col-year">{{ item.year ?? '—' }}</td>
@@ -194,8 +371,10 @@ function venue(item: LibraryItem): string {
         </table>
 
         <div class="lib-empty" v-else-if="!loading">
-          <p>No items in library.</p>
-          <p class="lib-empty-sub">Add references via the Library menu, or import a .bib file.</p>
+          <p>{{ hasActiveFilter || filterQuery.collectionId || filterQuery.tagName ? 'No items match the current filter.' : 'No items in library.' }}</p>
+          <p class="lib-empty-sub" v-if="!hasActiveFilter && !filterQuery.collectionId && !filterQuery.tagName">
+            Add references via the Add button, or import a .bib file.
+          </p>
         </div>
       </div>
     </div>
@@ -206,9 +385,9 @@ function venue(item: LibraryItem): string {
         <div class="dp-header">
           <span class="dp-label">Source Detail</span>
           <button class="dp-close" @click="closePanel" title="Close">
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
-              <line x1="1" y1="1" x2="12" y2="12"/>
-              <line x1="12" y1="1" x2="1" y2="12"/>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+              <line x1="1" y1="1" x2="11" y2="11"/>
+              <line x1="11" y1="1" x2="1" y2="11"/>
             </svg>
           </button>
         </div>
@@ -257,6 +436,48 @@ function venue(item: LibraryItem): string {
             </div>
           </div>
 
+          <!-- Tags -->
+          <div class="dp-block" v-if="activeItem.tags && activeItem.tags.length > 0">
+            <div class="dp-block-label">Tags</div>
+            <div class="dp-tags">
+              <span
+                v-for="tagName in activeItem.tags"
+                :key="tagName"
+                class="dp-tag-chip"
+                :style="{
+                  background: (tagColorMap.get(tagName) ?? '#A5A4A2') + '22',
+                  color: tagColorMap.get(tagName) ?? '#A5A4A2',
+                  borderColor: (tagColorMap.get(tagName) ?? '#A5A4A2') + '55',
+                }"
+              >{{ tagName }}</span>
+            </div>
+          </div>
+
+          <!-- Collections membership -->
+          <div class="dp-block" v-if="collections.length > 0">
+            <div class="dp-block-label">Collections</div>
+            <div class="dp-coll-chips" v-if="activeItemCollections.length > 0">
+              <span
+                v-for="col in activeItemCollections"
+                :key="col.id"
+                class="dp-coll-chip"
+              >
+                {{ col.name }}
+                <button class="dp-coll-remove" @click="removeFromCol(col.id)" title="Remove from collection">×</button>
+              </span>
+            </div>
+            <div v-if="collectionsForAdd.length > 0" class="dp-coll-add">
+              <select v-model="addToCollId" class="dp-coll-select">
+                <option value="">+ Add to collection…</option>
+                <option v-for="col in collectionsForAdd" :key="col.id" :value="col.id">{{ col.name }}</option>
+              </select>
+              <button v-if="addToCollId" class="dp-coll-add-btn" @click="addToCol">Add</button>
+            </div>
+            <div v-if="activeItemCollections.length === 0 && collectionsForAdd.length === 0" class="dp-empty-hint">
+              No collections
+            </div>
+          </div>
+
           <div class="dp-block" v-if="activeItem.abstractText">
             <div class="dp-block-label">Abstract</div>
             <p class="dp-abstract">{{ activeItem.abstractText }}</p>
@@ -270,21 +491,21 @@ function venue(item: LibraryItem): string {
 
         <div class="dp-actions">
           <button class="dp-action-btn" @click="openEditForm(activeItem)" title="Edit entry">
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M9 1.5L11.5 4L5 10.5H2.5V8L9 1.5Z"/>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8.5 1.5L10.5 3.5L4.5 9.5H2.5V7.5L8.5 1.5Z"/>
             </svg>
             Edit
           </button>
           <button class="dp-action-btn" @click="duplicateItem(activeItem)" title="Duplicate entry">
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="4.5" y="4.5" width="7" height="7" rx="1"/>
-              <path d="M4.5 8.5H2.5a1 1 0 01-1-1v-5a1 1 0 011-1h5a1 1 0 011 1v2"/>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="4" y="4" width="7" height="7" rx="1"/>
+              <path d="M4 8H2.5a1 1 0 01-1-1V2.5a1 1 0 011-1H7a1 1 0 011 1V4"/>
             </svg>
             Duplicate
           </button>
           <button class="dp-action-btn danger" @click="requestDelete(activeItem)" title="Delete entry">
-            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M2 3.5h9M5 3.5V2h3v1.5M5.5 5.5v4M7.5 5.5v4M3 3.5l.5 7h6l.5-7"/>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 3.5h8M4.5 3.5V2h3v1.5M5 5.5v3.5M7 5.5v3.5M2.5 3.5l.5 6.5h6l.5-6.5"/>
             </svg>
             Delete
           </button>
@@ -335,21 +556,94 @@ function venue(item: LibraryItem): string {
 }
 
 .lib-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 20px 12px 24px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
+.lib-header-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px 10px 20px;
+}
+
+.lib-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+  flex-shrink: 0;
+}
+
+.lib-count {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.lib-count.loading {
+  font-style: italic;
+}
+
+/* Search */
+.lib-search-wrap {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  max-width: 360px;
+  margin-left: 4px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 9px;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.lib-search {
+  width: 100%;
+  height: 28px;
+  padding: 0 28px 0 28px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface-solid);
+  outline: none;
+  transition: border-color var(--t), box-shadow var(--t);
+}
+
+.lib-search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.search-clear {
+  position: absolute;
+  right: 7px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  padding: 2px;
+  border-radius: 2px;
+  transition: color var(--t);
+}
+.search-clear:hover { color: var(--text); }
+
 .add-btn {
-  margin-left: auto;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 5px;
   height: 28px;
-  padding: 0 12px;
+  padding: 0 11px;
   background: var(--accent);
   color: #fff;
   border: none;
@@ -361,23 +655,87 @@ function venue(item: LibraryItem): string {
 }
 .add-btn:hover { opacity: 0.88; }
 
-.lib-title {
-  font-size: 15px;
+/* Filter bar */
+.lib-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 16px 8px 20px;
+  flex-wrap: wrap;
+}
+
+.filter-pill {
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-medium);
+  border-radius: 11px;
+  font-family: var(--font-ui);
+  font-size: 10.5px;
   font-weight: 600;
-  color: var(--text);
-  letter-spacing: -0.01em;
-}
-
-.lib-count {
-  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  cursor: pointer;
+  background: none;
   color: var(--text-tertiary);
+  transition: background var(--t), color var(--t), border-color var(--t);
+}
+.filter-pill:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
+}
+
+.filter-sep {
+  flex: 0 0 1px;
+  height: 14px;
+  background: var(--border);
+  margin: 0 4px;
+}
+
+.year-range {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.year-input {
+  width: 52px;
+  height: 22px;
+  padding: 0 6px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--text);
+  background: none;
+  outline: none;
+  text-align: center;
   font-variant-numeric: tabular-nums;
+  transition: border-color var(--t);
+}
+.year-input:focus { border-color: var(--accent); }
+
+.year-dash {
+  font-size: 11px;
+  color: var(--text-tertiary);
 }
 
-.lib-count.loading {
-  font-style: italic;
+.filter-clear-btn {
+  margin-left: 4px;
+  height: 22px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 11px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
+  transition: opacity var(--t);
 }
+.filter-clear-btn:hover { opacity: 0.8; }
 
+/* Table */
 .lib-table-wrap {
   flex: 1;
   overflow-y: auto;
@@ -398,7 +756,7 @@ function venue(item: LibraryItem): string {
 }
 
 .lib-table th {
-  padding: 8px 12px 8px;
+  padding: 7px 12px;
   font-size: 10.5px;
   font-weight: 600;
   text-transform: uppercase;
@@ -409,22 +767,11 @@ function venue(item: LibraryItem): string {
   user-select: none;
 }
 
-.lib-table th.sortable {
-  cursor: pointer;
-}
+.lib-table th.sortable { cursor: pointer; }
+.lib-table th.sortable:hover { color: var(--text-secondary); }
+.lib-table th.sorted { color: var(--accent); }
 
-.lib-table th.sortable:hover {
-  color: var(--text-secondary);
-}
-
-.lib-table th.sorted {
-  color: var(--accent);
-}
-
-.sort-icon {
-  margin-left: 3px;
-  font-size: 10px;
-}
+.sort-icon { margin-left: 3px; font-size: 10px; }
 
 .lib-row {
   border-bottom: 1px solid var(--border);
@@ -432,48 +779,58 @@ function venue(item: LibraryItem): string {
   transition: background var(--t);
 }
 
-.lib-row:hover {
-  background: var(--bg-chrome);
-}
-
-.lib-row.active {
-  background: var(--accent-soft);
-}
+.lib-row:hover { background: var(--bg-chrome); }
+.lib-row.active { background: var(--accent-soft); }
 
 .lib-table td {
-  padding: 10px 12px;
+  padding: 9px 12px;
   vertical-align: middle;
 }
 
-.col-type {
-  width: 52px;
-}
+.col-type { width: 52px; }
 
 .col-authors {
-  width: 200px;
+  width: 190px;
   color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 200px;
+  max-width: 190px;
 }
 
 .col-year {
-  width: 60px;
+  width: 56px;
   color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
   text-align: right;
-  padding-right: 20px;
+  padding-right: 16px;
 }
 
 .row-title {
   font-weight: 500;
   color: var(--text);
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.4;
+}
+
+.row-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 4px;
+}
+
+.row-tag-chip {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  white-space: nowrap;
 }
 
 .type-badge {
@@ -503,7 +860,7 @@ function venue(item: LibraryItem): string {
 /* ── Detail panel ──────────────────────────────────────────────────────────── */
 
 .detail-panel {
-  width: 284px;
+  width: 280px;
   flex-shrink: 0;
   border-left: 1px solid var(--border);
   background: var(--surface-solid);
@@ -516,13 +873,13 @@ function venue(item: LibraryItem): string {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px 10px;
+  padding: 11px 14px 9px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
 .dp-label {
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.09em;
@@ -534,26 +891,23 @@ function venue(item: LibraryItem): string {
   border: none;
   cursor: pointer;
   color: var(--text-tertiary);
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-sm);
   transition: background var(--t), color var(--t);
 }
-.dp-close:hover {
-  background: var(--bg-chrome-active);
-  color: var(--text);
-}
+.dp-close:hover { background: var(--bg-chrome-active); color: var(--text); }
 
 .dp-body {
-  padding: 16px 16px 20px;
+  padding: 14px 14px 18px;
   overflow-y: auto;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 11px;
 }
 
 .dp-type-row {
@@ -570,7 +924,7 @@ function venue(item: LibraryItem): string {
 
 .dp-title {
   font-family: var(--font-doc);
-  font-size: 14px;
+  font-size: 13.5px;
   font-weight: 700;
   line-height: 1.45;
   color: var(--text);
@@ -582,16 +936,8 @@ function venue(item: LibraryItem): string {
   gap: 3px;
 }
 
-.dp-authors {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text);
-}
-
-.dp-venue {
-  font-size: 11px;
-  color: var(--text-secondary);
-}
+.dp-authors { font-size: 12px; font-weight: 500; color: var(--text); }
+.dp-venue { font-size: 11px; color: var(--text-secondary); }
 
 .dp-doi {
   font-family: var(--font-mono);
@@ -605,14 +951,14 @@ function venue(item: LibraryItem): string {
 .dp-fields {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 14px;
+  gap: 5px 12px;
 }
 
 .dp-field {
   display: flex;
   align-items: baseline;
   gap: 4px;
-  font-size: 11.5px;
+  font-size: 11px;
 }
 
 .dp-field-label {
@@ -637,15 +983,107 @@ function venue(item: LibraryItem): string {
   color: var(--text-tertiary);
 }
 
+/* Tags in detail panel */
+.dp-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.dp-tag-chip {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+/* Collections in detail panel */
+.dp-coll-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 5px;
+}
+
+.dp-coll-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 6px 2px 8px;
+  background: var(--bg-chrome);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+}
+
+.dp-coll-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  line-height: 1;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  transition: color var(--t);
+}
+.dp-coll-remove:hover { color: #C0392B; }
+
+.dp-coll-add {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dp-coll-select {
+  flex: 1;
+  height: 26px;
+  padding: 0 6px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  background: var(--bg);
+  outline: none;
+  cursor: pointer;
+}
+
+.dp-coll-add-btn {
+  height: 26px;
+  padding: 0 10px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity var(--t);
+  flex-shrink: 0;
+}
+.dp-coll-add-btn:hover { opacity: 0.88; }
+
+.dp-empty-hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
 .dp-abstract {
   font-family: var(--font-doc);
-  font-size: 12.5px;
+  font-size: 12px;
   line-height: 1.65;
   color: var(--text-secondary);
 }
 
 .dp-keywords {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -656,7 +1094,7 @@ function venue(item: LibraryItem): string {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 8px 10px 10px;
+  padding: 7px 8px 9px;
   border-top: 1px solid var(--border);
   flex-shrink: 0;
 }
@@ -678,11 +1116,7 @@ function venue(item: LibraryItem): string {
   text-align: left;
 }
 
-.dp-action-btn:hover {
-  background: var(--bg-chrome-active);
-  color: var(--text);
-}
-
+.dp-action-btn:hover { background: var(--bg-chrome-active); color: var(--text); }
 .dp-action-btn.danger { color: #C0392B; }
 .dp-action-btn.danger:hover { background: rgba(192, 57, 43, 0.08); }
 
@@ -741,16 +1175,9 @@ function venue(item: LibraryItem): string {
   transition: opacity var(--t), background var(--t);
 }
 
-.fs-btn.secondary {
-  background: var(--bg-chrome-active);
-  color: var(--text-secondary);
-}
+.fs-btn.secondary { background: var(--bg-chrome-active); color: var(--text-secondary); }
 .fs-btn.secondary:hover { opacity: 0.8; }
-
-.fs-btn.danger {
-  background: #C0392B;
-  color: #fff;
-}
+.fs-btn.danger { background: #C0392B; color: #fff; }
 .fs-btn.danger:hover { opacity: 0.88; }
 
 /* ── Transition ────────────────────────────────────────────────────────────── */

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -89,7 +89,8 @@ async function loadPdf() {
     // before we try to render into it (canvas is inside v-else)
     loading.value = false
     await nextTick()
-    await renderPage(1)
+    const startPage = route.query.page ? Math.max(1, Number(route.query.page)) : 1
+    await renderPage(startPage)
     await loadAnnotations(attachmentId.value)
     renderAnnotationOverlay()
   } catch (e) {

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -1,145 +1,442 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, shallowRef, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { invoke } from '@tauri-apps/api/core'
+import * as pdfjsLib from 'pdfjs-dist'
+import { useAnnotations, type AnnotationInput } from '../composables/useAnnotations'
+import type { Annotation } from '../composables/useAnnotations'
 
-const currentPage = ref(3)
-const totalPages = 18
+// @ts-ignore — Vite resolves this at build time
+import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl
 
-function prevPage() {
-  if (currentPage.value > 1) currentPage.value--
+// ── Route ──────────────────────────────────────────────────────────────────────
+
+const route  = useRoute()
+const router = useRouter()
+
+const attachmentId = computed(() => Number(route.query.id))
+const itemId       = computed(() => Number(route.query.itemId))
+const fileName     = computed(() => (route.query.name as string) || 'PDF Viewer')
+
+// ── PDF state ──────────────────────────────────────────────────────────────────
+
+// shallowRef prevents Vue from Proxy-wrapping the pdfjs document instance.
+// pdfjs v5 uses private class fields (#field) which break when accessed through a Proxy.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pdfDoc = shallowRef<any>(null)
+const currentPage = ref(1)
+const totalPages  = ref(0)
+const scale       = ref(1.5)
+const loading     = ref(true)
+const pdfError    = ref('')
+
+// ── DOM refs ───────────────────────────────────────────────────────────────────
+
+const pageContainerEl = ref<HTMLElement | null>(null)
+const canvasEl        = ref<HTMLCanvasElement | null>(null)
+const textLayerEl     = ref<HTMLElement | null>(null)
+const annLayerEl      = ref<HTMLElement | null>(null)
+
+// ── Annotations ────────────────────────────────────────────────────────────────
+
+const { annotations, loadAnnotations, createAnnotation, deleteAnnotation, updateAnnotationNote } = useAnnotations()
+
+interface FloatingToolbar {
+  x: number
+  y: number
+  text: string
+  rects: Array<{ x1: number; y1: number; x2: number; y2: number }>
 }
-function nextPage() {
-  if (currentPage.value < totalPages) currentPage.value++
-}
+const floatingToolbar = ref<FloatingToolbar | null>(null)
+const editingNoteId   = ref<number | null>(null)
+const editingNoteText = ref('')
 
-const citingDrafts = [
-  { id: 1, title: 'Allergen Labelling in Packaged Foods (current)' },
-  { id: 2, title: 'FSSAI Comparative Analysis — Seminar Draft' },
+const ANN_COLORS = [
+  { hex: '#FACC15', label: 'Yellow' },
+  { hex: '#60A5FA', label: 'Blue'   },
+  { hex: '#4ADE80', label: 'Green'  },
+  { hex: '#F472B6', label: 'Pink'   },
 ]
 
-const annotations = [
-  {
-    id: 1,
-    stat: '34%',
-    statLabel: 'non-compliance rate (n=847)',
-    note: 'Key baseline for RQ2.',
-    page: 'p. 847',
-    color: '#0A5FBF',
-  },
-  {
-    id: 2,
-    stat: '#1',
-    statLabel: 'peanut — highest risk category',
-    note: 'Supports our methods focus.',
-    page: 'p. 312',
-    color: '#0A5FBF',
-  },
-  {
-    id: 3,
-    stat: '14',
-    statLabel: 'countries in sampling frame',
-    note: 'Good comparative scope. Check if India included.',
-    page: 'p. 6',
-    color: '#0A5FBF',
-  },
-]
+const pageAnnotations = computed(() =>
+  annotations.value.filter(a => a.page === currentPage.value)
+)
+
+const LAST_PDF_KEY = 'quire:lastPdf'
+
+// ── PDF loading ────────────────────────────────────────────────────────────────
+
+async function loadPdf() {
+  if (!attachmentId.value) {
+    loading.value = false
+    return
+  }
+  loading.value = true
+  pdfError.value = ''
+  try {
+    const bytes = await invoke<number[]>('read_attachment_bytes', { id: attachmentId.value })
+    const uint8 = new Uint8Array(bytes)
+    pdfDoc.value = await pdfjsLib.getDocument({ data: uint8 }).promise
+    totalPages.value = pdfDoc.value.numPages
+    // Persist last-opened PDF so the tab restores it on next visit
+    localStorage.setItem(LAST_PDF_KEY, JSON.stringify({
+      id:     attachmentId.value,
+      itemId: itemId.value,
+      name:   fileName.value,
+    }))
+    // Must set loading = false and await nextTick so the canvas enters the DOM
+    // before we try to render into it (canvas is inside v-else)
+    loading.value = false
+    await nextTick()
+    await renderPage(1)
+    await loadAnnotations(attachmentId.value)
+    renderAnnotationOverlay()
+  } catch (e) {
+    pdfError.value = String(e)
+    loading.value = false
+  }
+}
+
+// ── Page rendering ─────────────────────────────────────────────────────────────
+
+async function renderPage(pageNum: number) {
+  if (!pdfDoc.value || !canvasEl.value || !textLayerEl.value || !pageContainerEl.value) return
+  currentPage.value = pageNum
+  floatingToolbar.value = null
+
+  const page     = await pdfDoc.value.getPage(pageNum)
+  const viewport = page.getViewport({ scale: scale.value })
+
+  // Canvas
+  const canvas = canvasEl.value
+  const ctx    = canvas.getContext('2d')!
+  canvas.width  = viewport.width
+  canvas.height = viewport.height
+  pageContainerEl.value.style.width  = viewport.width  + 'px'
+  pageContainerEl.value.style.height = viewport.height + 'px'
+  await page.render({ canvasContext: ctx, viewport }).promise
+
+  // Text layer — pdfjs v5 uses the TextLayer class; renderTextLayer was removed
+  const textLayer = textLayerEl.value
+  textLayer.innerHTML = ''
+  // --total-scale-factor must be set BEFORE TextLayer constructor so that the
+  // CSS calc() dimensions resolve correctly when the browser lays out the container.
+  textLayer.style.setProperty('--total-scale-factor', String(scale.value))
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tl = new (pdfjsLib as any).TextLayer({
+      textContentSource: page.streamTextContent(),
+      container: textLayer,
+      viewport,
+    })
+    await tl.render()
+  } catch (e) {
+    console.warn('[pdf] text layer:', e)
+  }
+  // Force explicit pixel dimensions so the container always matches the canvas,
+  // even if the CSS-variable calc produced a slightly different rounding.
+  textLayer.style.width  = viewport.width  + 'px'
+  textLayer.style.height = viewport.height + 'px'
+
+  await nextTick()
+  renderAnnotationOverlay()
+}
+
+// ── Annotation overlay ─────────────────────────────────────────────────────────
+
+function renderAnnotationOverlay() {
+  if (!annLayerEl.value) return
+  annLayerEl.value.innerHTML = ''
+  for (const ann of pageAnnotations.value) {
+    let pos: { rects: Array<{ x1: number; y1: number; x2: number; y2: number }> }
+    try { pos = JSON.parse(ann.positionJson) } catch { continue }
+    for (const r of pos.rects ?? []) {
+      const div = document.createElement('div')
+      const isUnderline = ann.annType === 'underline'
+      div.style.cssText = `
+        position:absolute;
+        left:${r.x1 * 100}%;
+        top:${r.y1 * 100}%;
+        width:${(r.x2 - r.x1) * 100}%;
+        height:${(r.y2 - r.y1) * 100}%;
+        background:${isUnderline ? 'transparent' : ann.color + '55'};
+        border-bottom:${isUnderline ? '2px solid ' + ann.color : 'none'};
+        pointer-events:none;
+      `
+      annLayerEl.value.appendChild(div)
+    }
+  }
+}
+
+watch(pageAnnotations, renderAnnotationOverlay)
+
+// ── Text selection → floating toolbar ─────────────────────────────────────────
+
+function onMouseUp(event: MouseEvent) {
+  // Clicks inside the toolbar itself must not dismiss it
+  if ((event.target as HTMLElement).closest('.ann-toolbar')) return
+
+  const sel = window.getSelection()
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0 || !textLayerEl.value) {
+    floatingToolbar.value = null
+    return
+  }
+  const range = sel.getRangeAt(0)
+  if (!textLayerEl.value.contains(range.commonAncestorContainer)) {
+    floatingToolbar.value = null
+    return
+  }
+
+  const container = pageContainerEl.value!
+  const cRect     = container.getBoundingClientRect()
+  const rects: FloatingToolbar['rects'] = []
+  let minTop = Infinity
+
+  for (const r of Array.from(range.getClientRects())) {
+    if (r.width < 1) continue
+    rects.push({
+      x1: (r.left   - cRect.left) / cRect.width,
+      y1: (r.top    - cRect.top)  / cRect.height,
+      x2: (r.right  - cRect.left) / cRect.width,
+      y2: (r.bottom - cRect.top)  / cRect.height,
+    })
+    if (r.top < minTop) minTop = r.top
+  }
+  if (!rects.length) return
+
+  // Position toolbar centred on mouse X, above the top of the selection
+  floatingToolbar.value = {
+    x: event.clientX,
+    y: minTop - 52,
+    text: sel.toString().trim(),
+    rects,
+  }
+}
+
+async function createHighlight(color: string, annType = 'highlight') {
+  if (!floatingToolbar.value) return
+  const input: AnnotationInput = {
+    itemId:       itemId.value,
+    attachmentId: attachmentId.value,
+    page:         currentPage.value,
+    annType,
+    color,
+    selectedText: floatingToolbar.value.text,
+    positionJson: JSON.stringify({ rects: floatingToolbar.value.rects }),
+  }
+  await createAnnotation(input)
+  window.getSelection()?.removeAllRanges()
+  floatingToolbar.value = null
+  renderAnnotationOverlay()
+}
+
+// ── Navigation ─────────────────────────────────────────────────────────────────
+
+function prevPage() { if (currentPage.value > 1) renderPage(currentPage.value - 1) }
+function nextPage() { if (currentPage.value < totalPages.value) renderPage(currentPage.value + 1) }
+function zoomIn()  { scale.value = Math.min(scale.value + 0.25, 3); renderPage(currentPage.value) }
+function zoomOut() { scale.value = Math.max(scale.value - 0.25, 0.5); renderPage(currentPage.value) }
+function goBack()  { router.back() }
+
+// ── Inline note editing ────────────────────────────────────────────────────────
+
+function startEditNote(ann: Annotation) {
+  editingNoteId.value  = ann.id
+  editingNoteText.value = ann.noteText ?? ''
+}
+async function saveNote(id: number) {
+  await updateAnnotationNote(id, editingNoteText.value)
+  editingNoteId.value = null
+}
+
+// ── Delete annotation ──────────────────────────────────────────────────────────
+
+async function removeAnnotation(id: number) {
+  await deleteAnnotation(id)
+  renderAnnotationOverlay()
+}
+
+// ── Jump to annotation page ────────────────────────────────────────────────────
+
+function jumpToPage(page: number) {
+  if (page !== currentPage.value) renderPage(page)
+}
+
+// ── Standalone note (no text selection) ───────────────────────────────────────
+
+async function addStandaloneNote() {
+  const input: AnnotationInput = {
+    itemId:       itemId.value,
+    attachmentId: attachmentId.value,
+    page:         currentPage.value,
+    annType:      'note',
+    color:        '#FACC15',
+    positionJson: JSON.stringify({ rects: [] }),
+  }
+  const ann = await createAnnotation(input)
+  await nextTick()
+  startEditNote(ann)
+}
+
+// ── Global mouse listener ──────────────────────────────────────────────────────
+
+onMounted(() => {
+  document.addEventListener('mouseup', onMouseUp)
+  // If no attachment ID in route, restore the last-viewed PDF
+  if (!attachmentId.value) {
+    try {
+      const saved = localStorage.getItem(LAST_PDF_KEY)
+      if (saved) {
+        const { id, itemId: iid, name } = JSON.parse(saved)
+        router.replace({ path: '/pdf', query: { id, itemId: iid, name } })
+        return  // watch(attachmentId) will trigger loadPdf once query is set
+      }
+    } catch { /* corrupt localStorage — ignore */ }
+  }
+  loadPdf()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mouseup', onMouseUp)
+  if (pdfDoc.value) { pdfDoc.value.destroy(); pdfDoc.value = null }
+})
+
+watch(attachmentId, () => {
+  if (attachmentId.value) loadPdf()
+})
 </script>
 
 <template>
   <div class="pdf-view">
-    <!-- PDF reading area -->
-    <div class="pdf-area">
-      <div class="pdf-page">
-        <!-- Simulated page header -->
-        <div class="sim-header">
-          <div class="sim-line short"></div>
-          <div class="sim-line xshort"></div>
+
+    <!-- ── Header ────────────────────────────────────────────────────────────── -->
+    <div class="pdf-header">
+      <button class="back-btn" @click="goBack" title="Back to library">
+        <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M8 2L3 6.5l5 4.5"/>
+        </svg>
+        Library
+      </button>
+      <span class="pdf-title">{{ fileName || 'PDF Viewer' }}</span>
+      <div class="pdf-controls">
+        <button class="ctrl-btn" @click="zoomOut" title="Zoom out">−</button>
+        <span class="zoom-label">{{ Math.round(scale * 100) }}%</span>
+        <button class="ctrl-btn" @click="zoomIn"  title="Zoom in">+</button>
+        <div class="page-nav">
+          <button class="ctrl-btn" @click="prevPage" :disabled="currentPage <= 1">‹</button>
+          <span class="page-counter">
+            <input
+              class="page-input"
+              type="number"
+              :value="currentPage"
+              :min="1"
+              :max="totalPages"
+              @change="renderPage(Number(($event.target as HTMLInputElement).value))"
+            />
+            <span class="page-sep">/ {{ totalPages }}</span>
+          </span>
+          <button class="ctrl-btn" @click="nextPage" :disabled="currentPage >= totalPages">›</button>
         </div>
-
-        <!-- Simulated content with a highlight block -->
-        <div class="sim-content">
-          <div class="sim-line full"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line three-quarter"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line half"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line two-third"></div>
-
-          <!-- Highlighted section -->
-          <div class="highlight-block">
-            <div class="sim-line full highlighted"></div>
-            <div class="sim-line three-quarter highlighted"></div>
-            <div class="sim-line full highlighted"></div>
-            <div class="highlight-annotation">
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                <path d="M1.5 1.5h9v7h-3l-1.5 2-1.5-2H1.5v-7Z"/>
-              </svg>
-              Your annotation: Key baseline stat for RQ2 — cross-check with FSSAI
-            </div>
-          </div>
-
-          <div class="sim-line full"></div>
-          <div class="sim-line three-quarter"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line half"></div>
-          <div class="sim-line full"></div>
-          <div class="sim-line two-third"></div>
-          <div class="sim-line full"></div>
-        </div>
-      </div>
-
-      <!-- Page nav -->
-      <div class="pdf-nav">
-        <button class="nav-btn" @click="prevPage" :disabled="currentPage <= 1">
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M9 2L4 7l5 5"/>
-          </svg>
-        </button>
-        <span class="page-counter">{{ currentPage }} <span class="page-of">of</span> {{ totalPages }}</span>
-        <button class="nav-btn" @click="nextPage" :disabled="currentPage >= totalPages">
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M5 2l5 5-5 5"/>
-          </svg>
-        </button>
       </div>
     </div>
 
-    <!-- Right metadata panel -->
-    <div class="meta-panel">
-      <!-- Citing drafts -->
-      <div class="meta-section">
-        <div class="meta-label">
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M2 9V5a1 1 0 011-1h6a1 1 0 011 1v4a1 1 0 01-1 1H3a1 1 0 01-1-1Z"/>
-            <path d="M4 4V3a1 1 0 011-1h2a1 1 0 011 1v1"/>
+    <!-- ── Body ──────────────────────────────────────────────────────────────── -->
+    <div class="pdf-body">
+
+      <!-- PDF canvas area -->
+      <div class="pdf-scroll">
+        <div v-if="loading" class="pdf-loading">Loading…</div>
+        <div v-else-if="pdfError" class="pdf-error">{{ pdfError }}</div>
+        <div v-else-if="!pdfDoc" class="pdf-empty-state">
+          <svg width="40" height="40" viewBox="0 0 40 40" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.3">
+            <rect x="8" y="4" width="24" height="32" rx="2"/>
+            <path d="M14 13h12M14 19h12M14 25h8"/>
           </svg>
-          Your drafts citing this paper
+          <p>No PDF open</p>
+          <p class="pdf-empty-hint">Open a PDF from the library</p>
         </div>
-        <div class="drafts-list">
-          <div v-for="draft in citingDrafts" :key="draft.id" class="draft-row">
-            <div class="draft-dot"></div>
-            <span class="draft-title">{{ draft.title }}</span>
+        <div v-else class="page-wrap">
+          <div class="page-container" ref="pageContainerEl" @dragstart.prevent>
+            <canvas ref="canvasEl"></canvas>
+            <div class="text-layer" ref="textLayerEl"></div>
+            <div class="ann-layer"  ref="annLayerEl"></div>
           </div>
         </div>
       </div>
 
-      <!-- Your annotations -->
-      <div class="meta-section">
-        <div class="meta-label">
+      <!-- Floating annotation toolbar -->
+      <div
+        v-if="floatingToolbar"
+        class="ann-toolbar"
+        :style="{ left: floatingToolbar.x + 'px', top: floatingToolbar.y + 'px' }"
+        @mousedown.prevent
+      >
+        <button
+          v-for="c in ANN_COLORS"
+          :key="c.hex"
+          class="ann-color-btn"
+          :style="{ background: c.hex }"
+          :title="'Highlight ' + c.label"
+          @click="createHighlight(c.hex, 'highlight')"
+        ></button>
+        <button class="ann-underline-btn" title="Underline" @click="createHighlight('#0A5FBF', 'underline')">U̲</button>
+        <button class="ann-close-btn" @click="floatingToolbar = null">×</button>
+      </div>
+
+      <!-- Right panel: annotations list -->
+      <div class="ann-panel">
+        <div class="ann-panel-header">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
             <path d="M1 2h10M1 5h10M1 8h6"/>
           </svg>
-          Your annotations
+          Annotations
+          <span class="ann-count" v-if="annotations.length > 0">{{ annotations.length }}</span>
+          <button
+            v-if="attachmentId"
+            class="add-note-btn"
+            @click="addStandaloneNote"
+            title="Add note for this page"
+          >+ Note</button>
         </div>
+
+        <div v-if="annotations.length === 0" class="ann-empty">
+          Select text to highlight, or click <strong>+ Note</strong> to add a page note.
+        </div>
+
         <div class="ann-list">
-          <div v-for="ann in annotations" :key="ann.id" class="ann-row" :style="{ borderLeftColor: ann.color }">
-            <div class="ann-stat" :style="{ color: ann.color }">{{ ann.stat }}</div>
-            <div class="ann-body">
-              <div class="ann-label">{{ ann.statLabel }}</div>
-              <div class="ann-note">{{ ann.note }}</div>
-              <div class="ann-page">{{ ann.page }}</div>
+          <div
+            v-for="ann in annotations"
+            :key="ann.id"
+            class="ann-item"
+            :class="{ 'current-page': ann.page === currentPage }"
+            @click="jumpToPage(ann.page)"
+          >
+            <div class="ann-item-header">
+              <span class="ann-color-dot" :style="{ background: ann.color }"></span>
+              <span class="ann-page-tag">p.{{ ann.page }}</span>
+              <span class="ann-type-tag">{{ ann.annType }}</span>
+              <button class="ann-del-btn" @click.stop="removeAnnotation(ann.id)" title="Delete">×</button>
             </div>
+            <p v-if="ann.selectedText" class="ann-quote">"{{ ann.selectedText }}"</p>
+            <template v-if="editingNoteId === ann.id">
+              <textarea
+                v-model="editingNoteText"
+                class="ann-note-input"
+                placeholder="Add a note…"
+                @blur="saveNote(ann.id)"
+                @keydown.enter.exact.prevent="saveNote(ann.id)"
+                autofocus
+              ></textarea>
+              <p class="ann-note-hint">Enter to save · Shift+Enter for new line</p>
+            </template>
+            <p
+              v-else
+              class="ann-note"
+              :class="{ empty: !ann.noteText }"
+              @click.stop="startEditNote(ann)"
+              title="Click to edit note"
+            >{{ ann.noteText || 'Add note…' }}</p>
           </div>
         </div>
       </div>
@@ -150,142 +447,293 @@ const annotations = [
 <style scoped>
 .pdf-view {
   display: flex;
+  flex-direction: column;
   height: 100%;
   overflow: hidden;
+  background: var(--bg);
 }
 
-/* PDF area */
-.pdf-area {
-  flex: 1;
-  background: #DEDAD2;
+/* ── Header ──────────────────────────────────────────────────────────────────── */
+
+.pdf-header {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding: 24px 20px 16px;
-  gap: 14px;
-  overflow: hidden;
-  min-width: 0;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-chrome);
+  flex-shrink: 0;
 }
 
-.pdf-page {
-  flex: 1;
-  width: 100%;
-  max-width: 480px;
-  background: #FFFFFF;
+.back-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 4px 6px;
   border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-lg);
-  padding: 40px 44px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+  transition: background var(--t), color var(--t);
+}
+.back-btn:hover { background: var(--bg-document); color: var(--text); }
+
+.pdf-title {
+  flex: 1;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-/* Simulated header */
-.sim-header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #E0DDD7;
-}
-
-/* Simulated content */
-.sim-content {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-}
-
-/* Placeholder lines */
-.sim-line {
-  height: 9px;
-  background: #ECEAE5;
-  border-radius: 2px;
-}
-.sim-line.full        { width: 100%; }
-.sim-line.three-quarter { width: 74%; }
-.sim-line.two-third   { width: 65%; }
-.sim-line.half        { width: 48%; }
-.sim-line.short       { width: 32%; }
-.sim-line.xshort      { width: 20%; }
-.sim-line.highlighted {
-  background: rgba(250, 204, 21, 0.45);
-}
-
-/* Highlight block */
-.highlight-block {
-  background: rgba(250, 204, 21, 0.1);
-  border-left: 3px solid rgba(202, 138, 4, 0.55);
-  padding: 10px 12px;
-  border-radius: 2px 6px 6px 2px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin: 4px 0;
-}
-
-.highlight-annotation {
-  display: flex;
-  align-items: flex-start;
-  gap: 5px;
-  font-size: 10px;
-  color: #92400E;
-  font-style: italic;
-  padding-top: 5px;
-  border-top: 1px solid rgba(202, 138, 4, 0.25);
-  line-height: 1.4;
-}
-
-.highlight-annotation svg {
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-/* Page nav */
-.pdf-nav {
+.pdf-controls {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
   flex-shrink: 0;
 }
 
-.nav-btn {
+.ctrl-btn {
   background: var(--surface-solid);
   border: 1px solid var(--border-medium);
   border-radius: var(--radius-sm);
-  width: 28px;
-  height: 28px;
+  min-width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  font-size: 14px;
   color: var(--text-secondary);
-  transition: background var(--t), box-shadow var(--t);
+  padding: 0 4px;
+  transition: background var(--t);
 }
-.nav-btn:hover:not(:disabled) {
-  background: var(--bg-chrome);
-  box-shadow: var(--shadow-xs);
-}
-.nav-btn:disabled {
-  opacity: 0.3;
-  cursor: default;
-}
+.ctrl-btn:hover:not(:disabled) { background: var(--bg-chrome); }
+.ctrl-btn:disabled { opacity: 0.35; cursor: default; }
 
-.page-counter {
-  font-size: 12px;
-  color: var(--text-secondary);
-  min-width: 52px;
+.zoom-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  min-width: 34px;
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
-.page-of {
-  color: var(--text-tertiary);
+
+.page-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-/* Meta panel */
-.meta-panel {
-  width: 290px;
+.page-counter {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.page-input {
+  width: 36px;
+  height: 24px;
+  border: 1px solid var(--border-medium);
+  border-radius: 4px;
+  background: var(--surface-solid);
+  text-align: center;
+  font-size: 11.5px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  padding: 0;
+}
+.page-input::-webkit-inner-spin-button { display: none; }
+
+.page-sep {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Body ────────────────────────────────────────────────────────────────────── */
+
+.pdf-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* PDF scroll area */
+.pdf-scroll {
+  flex: 1;
+  overflow: auto;
+  background: var(--bg-document);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  min-width: 0;
+}
+
+.pdf-loading,
+.pdf-error {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  margin-top: 48px;
+}
+.pdf-error { color: #E8650A; }
+
+.pdf-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 80px;
+  color: var(--text-tertiary);
+}
+.pdf-empty-state p {
+  margin: 0;
+  font-size: 13px;
+}
+.pdf-empty-hint {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.page-wrap {
+  box-shadow: var(--shadow-lg);
+}
+
+.page-container {
+  position: relative;
+  display: inline-block;
+}
+
+.page-container canvas {
+  display: block;
+}
+
+.page-container canvas { z-index: 1; }
+
+.text-layer {
+  position: absolute;
+  top: 0; left: 0;
+  /* overflow:clip clips without creating a scroll container — overflow:hidden
+     blocks text-selection drag in Chromium/WebView2 */
+  overflow: clip;
+  pointer-events: auto;
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
+  z-index: 2;
+  line-height: 1;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+  /* pdfjs v5 CSS variable chain: --total-scale-factor is set per page via JS  */
+  --total-scale-factor: 1;
+  --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size, 1));
+}
+
+/* pdfjs v5 text spans: positioned by %, sized by CSS variable chain */
+.text-layer :deep(span),
+.text-layer :deep(br) {
+  color: transparent;
+  position: absolute;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* pdfjs v5: font-size and transform driven by CSS variables set inline per span */
+.text-layer :deep(span) {
+  --font-height: 0;
+  font-size: calc(var(--text-scale-factor) * var(--font-height));
+  --scale-x: 1;
+  --rotate: 0deg;
+  transform: rotate(var(--rotate)) scaleX(var(--scale-x));
+}
+
+.text-layer :deep(span)::selection,
+.text-layer :deep(::selection) {
+  background: rgba(10, 95, 191, 0.3);
+  color: transparent;
+}
+
+/* Annotation highlight overlay — above text-layer visually, no pointer events */
+.ann-layer {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 3;
+}
+
+/* ── Floating annotation toolbar ─────────────────────────────────────────────── */
+
+.ann-toolbar {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: #1C1C1E;
+  border-radius: 20px;
+  padding: 6px 10px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.35), 0 1px 4px rgba(0,0,0,0.2);
+  transform: translateX(-50%);
+  animation: toolbar-pop 0.1s ease-out;
+}
+
+@keyframes toolbar-pop {
+  from { opacity: 0; transform: translateX(-50%) scale(0.88); }
+  to   { opacity: 1; transform: translateX(-50%) scale(1); }
+}
+
+/* Separator between colors and actions */
+.ann-toolbar::after {
+  content: '';
+  width: 1px;
+  height: 16px;
+  background: rgba(255,255,255,0.15);
+  margin: 0 2px;
+}
+
+.ann-color-btn {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+}
+.ann-color-btn:hover {
+  transform: scale(1.2);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+
+.ann-underline-btn,
+.ann-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(255,255,255,0.7);
+  font-size: 13px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.1s;
+}
+.ann-underline-btn:hover { color: #fff; }
+.ann-close-btn:hover { color: #FF6B6B; }
+
+/* ── Annotation panel ─────────────────────────────────────────────────────────── */
+
+.ann-panel {
+  width: 260px;
   flex-shrink: 0;
   border-left: 1px solid var(--border);
   background: var(--bg-chrome);
@@ -294,24 +742,11 @@ const annotations = [
   overflow: hidden;
 }
 
-.meta-section {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border-bottom: 1px solid var(--border);
-  min-height: 0;
-}
-
-.meta-section:last-child {
-  border-bottom: none;
-}
-
-.meta-label {
+.ann-panel-header {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 11px 15px 9px;
+  padding: 8px 10px 8px 14px;
   font-size: 10.5px;
   font-weight: 600;
   color: var(--text-secondary);
@@ -319,90 +754,142 @@ const annotations = [
   flex-shrink: 0;
 }
 
-/* Citing drafts */
-.drafts-list {
-  padding: 12px 15px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  overflow-y: auto;
+.add-note-btn {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border-medium);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--t), color var(--t), border-color var(--t);
+}
+.add-note-btn:hover {
+  background: var(--bg-document);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
-.draft-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-}
-
-.draft-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
+.ann-count {
   background: var(--accent);
-  flex-shrink: 0;
-  margin-top: 4px;
+  color: #fff;
+  font-size: 9.5px;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 1px 5px;
+  margin-left: 2px;
 }
 
-.draft-title {
-  font-size: 12px;
-  color: var(--text);
-  line-height: 1.45;
+.ann-empty {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  padding: 16px 14px;
+  font-style: italic;
+  line-height: 1.5;
 }
 
-/* Annotations */
 .ann-list {
-  padding: 10px 15px;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  overflow-y: auto;
   flex: 1;
-}
-
-.ann-row {
-  background: var(--surface-solid);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  border-left-width: 2px;
+  overflow-y: auto;
   padding: 8px 10px;
   display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-
-.ann-stat {
-  font-size: 17px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  line-height: 1;
-  flex-shrink: 0;
-  padding-top: 1px;
-  font-family: var(--font-ui);
-}
-
-.ann-body {
-  display: flex;
   flex-direction: column;
-  gap: 2px;
-  flex: 1;
-  min-width: 0;
+  gap: 6px;
 }
 
-.ann-label {
-  font-size: 11.5px;
-  font-weight: 500;
-  color: var(--text);
-  line-height: 1.3;
+.ann-item {
+  background: var(--surface-solid);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 9px;
+  cursor: pointer;
+  transition: box-shadow var(--t), border-color var(--t);
+}
+.ann-item:hover { box-shadow: var(--shadow-xs); }
+.ann-item.current-page { border-color: var(--accent); }
+
+.ann-item-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 5px;
+}
+
+.ann-color-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ann-page-tag {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.ann-type-tag {
+  font-size: 9.5px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.ann-del-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  transition: color var(--t);
+}
+.ann-del-btn:hover { color: #E8650A; }
+
+.ann-quote {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+  margin: 0 0 4px;
+  line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .ann-note {
-  font-size: 10.5px;
+  font-size: 11px;
   color: var(--text-secondary);
-  font-style: italic;
+  margin: 0;
+  line-height: 1.4;
+  cursor: text;
+}
+.ann-note.empty { color: var(--text-tertiary); font-style: italic; }
+
+.ann-note-input {
+  width: 100%;
+  min-height: 56px;
+  font-size: 11px;
+  font-family: var(--font-ui);
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 4px 6px;
+  resize: vertical;
+  box-sizing: border-box;
 }
 
-.ann-page {
-  font-size: 10px;
+.ann-note-hint {
+  font-size: 9.5px;
   color: var(--text-tertiary);
+  margin: 3px 0 0;
+  font-style: italic;
 }
 </style>

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -1,50 +1,195 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
+import Heading from '@tiptap/extension-heading'
+import { Mathematics } from '@tiptap/extension-mathematics'
+import 'katex/dist/katex.min.css'
 import { CitationNode } from '../extensions/CitationNode'
 import { CitationSuggest } from '../extensions/CitationSuggest'
+import { SearchAndReplace, searchKey } from '../extensions/SearchAndReplace'
+import { SectionRef } from '../extensions/SectionRef'
+import { SectionRefSuggest } from '../extensions/SectionRefSuggest'
 import { emitter } from '../events'
-import { useDocument, type BibEntry } from '../composables/useDocument'
+import { useDocument, type BibEntry, type DocAuthor } from '../composables/useDocument'
 import { useFileOps } from '../composables/useFileOps'
+import { openUrl } from '@tauri-apps/plugin-opener'
+
+// Heading extended with a stable UUID `id` attribute for section cross-references
+const ExtendedHeading = Heading.configure({ levels: [1, 2, 3] }).extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      id: {
+        default: null,
+        parseHTML: (el: Element) => el.getAttribute('data-hid') ?? null,
+        renderHTML: (attrs: any) => attrs.id ? { 'data-hid': attrs.id } : {},
+      },
+    }
+  },
+})
 
 const router = useRouter()
-const { docTitle, docAuthors, citations, isDirty } = useDocument()
+const { docTitle, docSubtitle, docStatus, docDate, docAuthors, citations, isDirty } = useDocument()
 const { openDocument, saveDocument } = useFileOps()
 
 // ── Editor ────────────────────────────────────────────────────────────────────
 
 const INITIAL_CONTENT = `
-<h2>Abstract</h2>
-<p>The inadequate labelling of allergens in packaged foods poses significant public health risks, particularly for the estimated 220–520 million people globally affected by food allergies. This cross-sectional study examines allergen labelling compliance among packaged food manufacturers in India under the Food Safety and Standards (Labelling and Display) Regulations 2020, with comparative reference to EU Regulation 1169/2011 and the US FALCPA. We find systematic gaps in precautionary labelling practice and identify regulatory interpretation as a primary source of non-compliance.</p>
-<h2>1. Introduction</h2>
+<p><strong>Abstract.</strong> The inadequate labelling of allergens in packaged foods poses significant public health risks, particularly for the estimated 220–520 million people globally affected by food allergies. This cross-sectional study examines allergen labelling compliance among packaged food manufacturers in India under the Food Safety and Standards (Labelling and Display) Regulations 2020, with comparative reference to EU Regulation 1169/2011 and the US FALCPA. We find systematic gaps in precautionary labelling practice and identify regulatory interpretation as a primary source of non-compliance.</p>
+<h1>Introduction</h1>
 <p>Food allergy affects an estimated 1 in 8 consumers <span data-cite-key="fda2021" data-index="2"></span> in developed markets, with rising prevalence documented across South Asian populations. Despite regulatory frameworks mandating allergen disclosure, recent systematic reviews indicate that approximately 34% of packaged food products <span data-cite-key="popova2022" data-index="1"></span> show discrepancies between declared allergen content and actual ingredient composition.</p>
 <p>In the Indian context, the FSSAI has established a threshold of 10 mg/kg for individual allergen declarations under §4.2.1 of the 2020 labelling regulations <span data-cite-key="hadley2019" data-index="3"></span> yet enforcement mechanisms remain inconsistently applied across food category segments.</p>
 <p>The foundational challenge is not merely one of regulatory compliance, but of communication design: precautionary allergen labels such as "may contain" are routinely misinterpreted by consumers, <span data-cite-key="hadley2019" data-index="3"></span> undermining their protective function even where they are accurately applied.</p>
-<h2>2. Literature Review</h2>
+<h1>Literature Review</h1>
 <p>The landscape of allergen labelling research is characterised by a tension between regulatory prescription and real-world consumer behaviour. Foundational work by Hadley &amp; King (2019) <span data-cite-key="hadley2019" data-index="3"></span> established baseline comprehension rates for precautionary labelling across demographically stratified cohorts, finding that education level and prior allergy diagnosis are the primary moderators of label interpretation accuracy.</p>
 <p>Subsequent systematic review of manufacturing-side compliance by Popova et al. (2022) <span data-cite-key="popova2022" data-index="1"></span> extended this analysis to the supply chain, demonstrating that discrepancies originate as frequently in ingredient sourcing and cross-contact risk management as in the labelling design itself.</p>
-<h2>3. Methods</h2>
-<p>Cross-sectional analysis of n=340 SKUs sampled from organised retail in three Indian metro markets (Chennai, Pune, Hyderabad). Audit conducted against FSSAI 2020 labelling regulations with comparative coding against EU and US frameworks. Inter-rater reliability: κ = 0.87. [Draft continues…]</p>
+<h1>Methods</h1>
+<h2>Study design</h2>
+<p>Cross-sectional analysis of <em>n</em> = 340 SKUs sampled from organised retail in three Indian metro markets (Chennai, Pune, Hyderabad). Audit conducted against FSSAI 2020 labelling regulations with comparative coding against EU and US frameworks. Inter-rater reliability: κ = 0.87.</p>
+<h2>Statistical model</h2>
+<p>Compliance rate across product categories was modelled as a binomial proportion. The 95% confidence interval for overall non-compliance was computed as $\\hat{p} \\pm 1.96\\sqrt{\\hat{p}(1-\\hat{p})/n}$. Display-mode example:</p>
+$$\\kappa = \\frac{p_o - p_e}{1 - p_e}$$
+<p>[Draft continues…]</p>
 `
 
 const editor = useEditor({
   extensions: [
     StarterKit.configure({
-      heading: { levels: [2, 3] },
+      heading: false,
       horizontalRule: false,
       codeBlock: false,
       code: false,
     }),
+    ExtendedHeading,
+    Mathematics.configure({
+      blockOptions: { onClick: (node: any, pos: number) => openMathEdit(node, pos, 'blockMath') },
+      inlineOptions: { onClick: (node: any, pos: number) => openMathEdit(node, pos, 'inlineMath') },
+    }),
     CitationNode,
     CitationSuggest,
+    SectionRef,
+    SectionRefSuggest,
+    SearchAndReplace,
   ],
+  editorProps: {
+    attributes: { spellcheck: 'true' },
+  },
   content: INITIAL_CONTENT,
   onUpdate() {
     isDirty.value = true
   },
 })
+
+// ── Find & Replace ────────────────────────────────────────────────────────────
+
+const findOpen = ref(false)
+const showReplace = ref(false)
+const findTerm = ref('')
+const replaceTerm = ref('')
+const srCount = ref(0)
+const srCurrent = ref(-1)
+
+function syncSrState() {
+  const ps = editor.value ? searchKey.getState(editor.value.state) : null
+  srCount.value = ps?.matches.length ?? 0
+  srCurrent.value = ps?.current ?? -1
+}
+
+function openFind(withReplace = false) {
+  findOpen.value = true
+  showReplace.value = withReplace
+  setTimeout(() => (document.querySelector('.find-input') as HTMLElement | null)?.focus(), 30)
+}
+
+function closeFind() {
+  findOpen.value = false
+  findTerm.value = ''
+  replaceTerm.value = ''
+  editor.value?.commands.setSearch('')
+  srCount.value = 0
+  srCurrent.value = -1
+  editor.value?.commands.focus()
+}
+
+function onFindInput() {
+  editor.value?.commands.setSearch(findTerm.value)
+  syncSrState()
+  if (srCount.value > 0) {
+    editor.value?.commands.findNext()
+    syncSrState()
+  }
+}
+
+function doFindNext() {
+  editor.value?.commands.findNext()
+  syncSrState()
+}
+
+function doFindPrev() {
+  editor.value?.commands.findPrev()
+  syncSrState()
+}
+
+function doReplaceOne() {
+  editor.value?.commands.replaceOne(replaceTerm.value)
+  syncSrState()
+}
+
+function doReplaceAll() {
+  editor.value?.commands.replaceAll(replaceTerm.value)
+  syncSrState()
+}
+
+// ── Math edit overlay ─────────────────────────────────────────────────────────
+
+interface MathEditState {
+  visible: boolean
+  latex: string
+  pos: number
+  type: 'blockMath' | 'inlineMath'
+  style: { left: string; top: string }
+}
+
+const mathEdit = ref<MathEditState>({
+  visible: false,
+  latex: '',
+  pos: 0,
+  type: 'blockMath',
+  style: { left: '0px', top: '0px' },
+})
+
+function openMathEdit(node: any, pos: number, type: 'blockMath' | 'inlineMath') {
+  const dom = editor.value?.view.nodeDOM(pos) as HTMLElement | null
+  const rect = dom?.getBoundingClientRect()
+  mathEdit.value = {
+    visible: true,
+    latex: node.attrs.latex ?? '',
+    pos,
+    type,
+    style: {
+      left: `${rect ? Math.min(rect.left, window.innerWidth - 360) : 200}px`,
+      top: `${rect ? rect.bottom + 8 : 200}px`,
+    },
+  }
+  // focus the textarea after Vue renders
+  setTimeout(() => {
+    (document.querySelector('.math-edit-input') as HTMLElement | null)?.focus()
+  }, 30)
+}
+
+function applyMathEdit() {
+  if (!editor.value || !mathEdit.value.visible) return
+  const { pos, type, latex } = mathEdit.value
+  editor.value.chain().focus().setNodeSelection(pos).updateAttributes(type, { latex }).run()
+  mathEdit.value.visible = false
+}
+
+function closeMathEdit() {
+  mathEdit.value.visible = false
+  editor.value?.commands.focus()
+}
 
 // ── Tooltip state ─────────────────────────────────────────────────────────────
 
@@ -82,6 +227,9 @@ const activeCitation = ref<BibEntry | null>(null)
 
 async function handleKeydown(e: KeyboardEvent) {
   const ctrl = e.ctrlKey || e.metaKey
+  if (e.key === 'Escape') {
+    if (findOpen.value) { e.preventDefault(); closeFind(); return }
+  }
   if (!ctrl) return
   if (e.key === 's') {
     e.preventDefault()
@@ -95,6 +243,14 @@ async function handleKeydown(e: KeyboardEvent) {
       editor.value.commands.setContent(body)
       isDirty.value = false
     }
+  }
+  if (e.key === 'f') {
+    e.preventDefault()
+    openFind(false)
+  }
+  if (e.key === 'h') {
+    e.preventDefault()
+    openFind(true)
   }
 }
 
@@ -155,11 +311,56 @@ function openTooltipCitation() {
   if (!tooltipCitation.value) return
   activeCitation.value = tooltipCitation.value
   tooltipVisible.value = false
+  metaOpen.value = false
   panelOpen.value = true
 }
 
 function goToPdf() {
   router.push('/pdf')
+}
+
+// ── Metadata panel ────────────────────────────────────────────────────────────
+
+const metaOpen = ref(false)
+
+function openMeta() {
+  panelOpen.value = false
+  activeCitation.value = null
+  metaOpen.value = true
+}
+
+function addAuthor() {
+  docAuthors.value.push({ name: '', orcid: '', title: '', affiliation: '' })
+}
+
+function removeAuthor(i: number) {
+  docAuthors.value.splice(i, 1)
+}
+
+// ── Byline helpers ────────────────────────────────────────────────────────────
+
+const uniqueAffiliations = computed(() => {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const author of docAuthors.value) {
+    const aff = author.affiliation.trim()
+    if (aff && !seen.has(aff)) {
+      seen.add(aff)
+      result.push(aff)
+    }
+  }
+  return result
+})
+
+function affiliationNumbers(author: DocAuthor): number[] {
+  const aff = author.affiliation.trim()
+  if (!aff) return []
+  const idx = uniqueAffiliations.value.indexOf(aff)
+  return idx >= 0 ? [idx + 1] : []
+}
+
+function openOrcid(orcid: string) {
+  openUrl(`https://orcid.org/${orcid}`).catch(() => {})
 }
 </script>
 
@@ -168,17 +369,48 @@ function goToPdf() {
     <!-- Document scroll area -->
     <div class="document-area">
       <div class="paper">
-        <!-- Paper header — mirrors placeholder exactly -->
-        <div class="paper-eyebrow">Working Draft · April 2026</div>
+        <!-- Paper header -->
+        <div class="paper-eyebrow">
+          <span>{{ docStatus }}{{ docDate ? ' · ' + docDate : '' }}</span>
+          <button class="meta-trigger" @click="openMeta" title="Edit document metadata">
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8.5 1.5a1.414 1.414 0 0 1 2 2L3 11H1v-2L8.5 1.5z"/>
+            </svg>
+          </button>
+        </div>
         <h1 class="paper-title">{{ docTitle }}</h1>
-        <p class="paper-subtitle">A Cross-Sectional Study of FSSAI Compliance and Consumer Risk Communication</p>
+        <p class="paper-subtitle" v-if="docSubtitle">{{ docSubtitle }}</p>
         <div class="paper-byline">
-          <template v-for="(author, i) in docAuthors" :key="i">
-            <span>{{ author }}</span>
-            <span v-if="i < docAuthors.length - 1" class="by-sep">·</span>
-          </template>
-          <span class="by-sep">·</span>
-          <span>Food Policy Studies, IIT Madras</span>
+          <!-- Author names row -->
+          <div class="byline-authors">
+            <span v-for="(author, i) in docAuthors" :key="i" class="byline-author">
+              <span class="author-name">{{ author.name }}</span>
+              <sup v-if="uniqueAffiliations.length > 1 && affiliationNumbers(author).length" class="affil-sup">
+                {{ affiliationNumbers(author).join(',') }}
+              </sup>
+              <a
+                v-if="author.orcid"
+                class="orcid-link"
+                href="#"
+                @click.prevent="openOrcid(author.orcid)"
+                :title="`ORCID: ${author.orcid}`"
+              >
+                <svg class="orcid-logo" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="12" fill="#A6CE39"/>
+                  <rect x="7" y="7.5" width="2.2" height="9.5" rx="1" fill="white"/>
+                  <circle cx="8.1" cy="5.2" r="1.5" fill="white"/>
+                  <path d="M11.5 7.5h4.1c2.8 0 4.4 2 4.4 4.75S18.4 17 15.6 17H11.5V7.5z" fill="white"/>
+                </svg>
+              </a>
+              <span v-if="i < docAuthors.length - 1" class="by-sep"> · </span>
+            </span>
+          </div>
+          <!-- Affiliations row -->
+          <div v-if="uniqueAffiliations.length" class="byline-affiliations">
+            <span v-for="(aff, i) in uniqueAffiliations" :key="i" class="byline-affil">
+              <sup v-if="uniqueAffiliations.length > 1" class="affil-sup">{{ i + 1 }}</sup>{{ aff }}<span v-if="i < uniqueAffiliations.length - 1" class="by-sep">  ·  </span>
+            </span>
+          </div>
         </div>
         <div class="paper-rule"></div>
 
@@ -219,7 +451,152 @@ function goToPdf() {
         </div>
       </div>
     </Transition>
+
+    <!-- Metadata panel (slide in) -->
+    <Transition name="panel">
+      <div class="citation-panel meta-panel" v-if="metaOpen">
+        <div class="cp-header">
+          <span class="cp-label">Document</span>
+          <button class="cp-close" @click="metaOpen = false" title="Close">
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+              <line x1="1" y1="1" x2="12" y2="12"/>
+              <line x1="12" y1="1" x2="1" y2="12"/>
+            </svg>
+          </button>
+        </div>
+        <div class="cp-body mp-body">
+
+          <!-- Title -->
+          <div class="mp-group">
+            <div class="mp-group-label">Title</div>
+            <input class="mp-input" v-model="docTitle" type="text" placeholder="Paper title" />
+          </div>
+
+          <!-- Subtitle -->
+          <div class="mp-group">
+            <div class="mp-group-label">Subtitle</div>
+            <input class="mp-input" v-model="docSubtitle" type="text" placeholder="Subtitle or description" />
+          </div>
+
+          <!-- Status + Date row -->
+          <div class="mp-row">
+            <div class="mp-group mp-half">
+              <div class="mp-group-label">Status</div>
+              <input class="mp-input" v-model="docStatus" type="text" placeholder="Working Draft" />
+            </div>
+            <div class="mp-group mp-half">
+              <div class="mp-group-label">Date</div>
+              <input class="mp-input" v-model="docDate" type="text" placeholder="April 2026" />
+            </div>
+          </div>
+
+          <div class="mp-divider"></div>
+
+          <!-- Authors -->
+          <div class="mp-authors-header">
+            <span class="mp-group-label" style="margin-bottom:0">Authors</span>
+            <button class="mp-add-btn" @click="addAuthor">+ Add</button>
+          </div>
+
+          <div v-for="(author, i) in docAuthors" :key="i" class="mp-author-card">
+            <div class="mp-author-row">
+              <div class="mp-group" style="flex:1">
+                <div class="mp-group-label">Name</div>
+                <input class="mp-input" v-model="author.name" type="text" placeholder="Surname, Initials" />
+              </div>
+              <button v-if="docAuthors.length > 1" class="mp-remove-btn" @click="removeAuthor(i)" title="Remove author">
+                <svg width="11" height="11" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+                  <line x1="1" y1="1" x2="12" y2="12"/><line x1="12" y1="1" x2="1" y2="12"/>
+                </svg>
+              </button>
+            </div>
+            <div class="mp-group">
+              <div class="mp-group-label">ORCID</div>
+              <input class="mp-input mp-mono" v-model="author.orcid" type="text" placeholder="0000-0000-0000-0000" />
+            </div>
+            <div class="mp-row">
+              <div class="mp-group mp-half">
+                <div class="mp-group-label">Position</div>
+                <input class="mp-input" v-model="author.title" type="text" placeholder="PhD Candidate" />
+              </div>
+              <div class="mp-group mp-half">
+                <div class="mp-group-label">Affiliation</div>
+                <input class="mp-input" v-model="author.affiliation" type="text" placeholder="Institution" />
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </Transition>
   </div>
+
+  <!-- Find & Replace bar -->
+  <Teleport to="body">
+    <Transition name="find-bar">
+      <div v-if="findOpen" class="find-bar">
+
+        <!-- Find row -->
+        <div class="find-row">
+          <div class="find-input-wrap">
+            <svg class="find-icon" width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
+              <circle cx="5.5" cy="5.5" r="4"/>
+              <line x1="8.5" y1="8.5" x2="12" y2="12"/>
+            </svg>
+            <input
+              class="find-input"
+              v-model="findTerm"
+              placeholder="Find…"
+              @input="onFindInput"
+              @keydown.enter.exact.prevent="doFindNext"
+              @keydown.shift.enter.prevent="doFindPrev"
+              @keydown.escape.prevent="closeFind"
+            />
+            <span class="find-count" v-if="findTerm">
+              {{ srCount === 0 ? 'No results' : `${srCurrent >= 0 ? srCurrent + 1 : '?'} / ${srCount}` }}
+            </span>
+          </div>
+          <button class="find-nav-btn" @click="doFindPrev" title="Previous (Shift+Enter)">
+            <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 7l3.5-3.5L9 7"/>
+            </svg>
+          </button>
+          <button class="find-nav-btn" @click="doFindNext" title="Next (Enter)">
+            <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 4l3.5 3.5L9 4"/>
+            </svg>
+          </button>
+          <button class="find-toggle-btn" :class="{ active: showReplace }" @click="showReplace = !showReplace" title="Toggle replace">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M1 4h7M5 2l3 2-3 2"/>
+              <path d="M11 8H4M8 6l-3 2 3 2"/>
+            </svg>
+          </button>
+          <button class="find-close-btn" @click="closeFind" title="Close (Esc)">
+            <svg width="11" height="11" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round">
+              <line x1="1" y1="1" x2="12" y2="12"/><line x1="12" y1="1" x2="1" y2="12"/>
+            </svg>
+          </button>
+        </div>
+
+        <!-- Replace row -->
+        <div class="find-row find-replace-row" v-if="showReplace">
+          <div class="find-input-wrap">
+            <input
+              class="find-input"
+              v-model="replaceTerm"
+              placeholder="Replace with…"
+              @keydown.enter.exact.prevent="doReplaceOne"
+              @keydown.escape.prevent="closeFind"
+            />
+          </div>
+          <button class="find-action-btn" @click="doReplaceOne" :disabled="srCount === 0">Replace</button>
+          <button class="find-action-btn" @click="doReplaceAll" :disabled="srCount === 0">All</button>
+        </div>
+
+      </div>
+    </Transition>
+  </Teleport>
 
   <!-- Tooltip -->
   <Teleport to="body">
@@ -237,6 +614,34 @@ function goToPdf() {
         <button class="tt-cta" @click="openTooltipCitation">View in detail →</button>
       </template>
     </div>
+  </Teleport>
+
+  <!-- Math edit overlay -->
+  <Teleport to="body">
+    <div
+      v-if="mathEdit.visible"
+      class="math-edit-overlay"
+      :style="mathEdit.style"
+    >
+      <div class="math-edit-label">{{ mathEdit.type === 'blockMath' ? 'Display math' : 'Inline math' }}</div>
+      <textarea
+        v-model="mathEdit.latex"
+        class="math-edit-input"
+        :rows="mathEdit.type === 'blockMath' ? 3 : 1"
+        @keydown.ctrl.enter.prevent="applyMathEdit"
+        @keydown.meta.enter.prevent="applyMathEdit"
+        @keydown.enter.exact.prevent="mathEdit.type === 'inlineMath' && applyMathEdit()"
+        @keydown.escape.prevent="closeMathEdit"
+      ></textarea>
+      <div class="math-edit-hint">{{ mathEdit.type === 'inlineMath' ? 'Enter to apply' : 'Ctrl+Enter to apply' }} · Esc to cancel</div>
+    </div>
+
+    <!-- click outside to close math editor -->
+    <div
+      v-if="mathEdit.visible"
+      style="position:fixed;inset:0;z-index:9997"
+      @mousedown.self="closeMathEdit"
+    ></div>
   </Teleport>
 </template>
 
@@ -269,12 +674,37 @@ function goToPdf() {
 }
 
 .paper-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 10.5px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   margin-bottom: 14px;
+}
+
+.meta-trigger {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity var(--t), background var(--t), color var(--t);
+}
+
+.paper-eyebrow:hover .meta-trigger {
+  opacity: 1;
+}
+
+.meta-trigger:hover {
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
 }
 
 .paper-title {
@@ -298,15 +728,78 @@ function goToPdf() {
 
 .paper-byline {
   display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 24px;
+}
+
+.byline-authors {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-size: 12.5px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.byline-author {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1px;
+  white-space: nowrap;
+}
+
+.author-name {
+  letter-spacing: -0.01em;
+}
+
+.affil-sup {
+  font-size: 8.5px;
+  vertical-align: super;
+  line-height: 0;
+  color: var(--text-secondary);
+  font-weight: 400;
+  margin-left: 1px;
+}
+
+.orcid-link {
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  margin-left: 3px;
+  vertical-align: middle;
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity var(--t);
+  position: relative;
+  top: -0.5px;
+}
+
+.orcid-link:hover {
+  opacity: 1;
+}
+
+.orcid-logo {
+  width: 13px;
+  height: 13px;
+  display: block;
+}
+
+.byline-affiliations {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
   font-size: 12px;
   color: var(--text-secondary);
-  margin-bottom: 24px;
+  font-style: italic;
+}
+
+.byline-affil {
+  display: inline;
 }
 
 .by-sep {
   color: var(--text-tertiary);
+  font-style: normal;
 }
 
 .paper-rule {
@@ -347,14 +840,14 @@ function goToPdf() {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .cp-close {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   width: 24px;
   height: 24px;
   display: flex;
@@ -404,8 +897,8 @@ function goToPdf() {
 
 .cp-doi {
   font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--text-tertiary);
+  font-size: 11px;
+  color: var(--text-secondary);
 }
 
 .cp-block {
@@ -419,7 +912,7 @@ function goToPdf() {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .cp-abstract {
@@ -457,6 +950,137 @@ function goToPdf() {
   transform: translateX(100%);
   opacity: 0;
 }
+
+/* ── Metadata panel ──────────────────────────────────────────── */
+
+.meta-panel {
+  border-left-color: var(--border-medium);
+}
+
+.mp-body {
+  gap: 12px;
+}
+
+.mp-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mp-group-label {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+  margin-bottom: 2px;
+}
+
+.mp-input {
+  background: var(--bg-chrome, #EDECEA);
+  border: 1px solid var(--border, rgba(0,0,0,0.09));
+  border-radius: 5px;
+  padding: 6px 8px;
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  color: var(--text);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color var(--t);
+}
+
+.mp-input:focus {
+  border-color: var(--accent);
+}
+
+.mp-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.mp-mono {
+  font-family: var(--font-mono, monospace);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+}
+
+.mp-row {
+  display: flex;
+  gap: 8px;
+}
+
+.mp-half {
+  flex: 1;
+  min-width: 0;
+}
+
+.mp-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.mp-authors-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.mp-add-btn {
+  background: none;
+  border: none;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background var(--t);
+}
+
+.mp-add-btn:hover {
+  background: var(--accent-soft);
+}
+
+.mp-author-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-chrome, #EDECEA);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.mp-author-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.mp-remove-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  padding: 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1px;
+  transition: background var(--t), color var(--t);
+}
+
+.mp-remove-btn:hover {
+  background: rgba(196, 80, 0, 0.08);
+  color: var(--accent-orange, #C45000);
+}
+
+/* override input background inside author card */
+.mp-author-card .mp-input {
+  background: var(--surface-solid, #fff);
+}
 </style>
 
 <!-- Tooltip global styles — not scoped, teleported to body -->
@@ -480,14 +1104,15 @@ function goToPdf() {
   font-family: Georgia, "Times New Roman", serif;
   font-size: 13px;
   font-weight: 700;
-  color: #1A1917;
+  color: var(--text);
   line-height: 1.4;
   margin-bottom: 4px;
 }
 
 .tt-authors {
-  font-size: 11px;
-  color: #6B6A68;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 
@@ -495,7 +1120,7 @@ function goToPdf() {
   font-family: Georgia, "Times New Roman", serif;
   font-size: 12px;
   line-height: 1.55;
-  color: #6B6A68;
+  color: var(--text-secondary);
   margin-bottom: 10px;
 }
 
@@ -505,10 +1130,171 @@ function goToPdf() {
   padding: 0;
   font-size: 11.5px;
   font-weight: 600;
-  color: #0A5FBF;
+  color: var(--accent);
   cursor: pointer;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 .tt-cta:hover { text-decoration: underline; }
+
+/* ── Find & Replace bar ──────────────────────────────────────── */
+
+.find-bar {
+  position: fixed;
+  top: calc(var(--titlebar-h, 42px) + 10px);
+  right: 28px;
+  z-index: 600;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+  min-width: 360px;
+}
+
+.find-bar-enter-active,
+.find-bar-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.find-bar-enter-from,
+.find-bar-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.find-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 8px 8px 10px;
+}
+
+.find-replace-row {
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+
+.find-input-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-chrome, #EDECEA);
+  border: 1px solid var(--border, rgba(0,0,0,0.09));
+  border-radius: 6px;
+  padding: 5px 8px;
+  min-width: 0;
+}
+
+.find-icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.find-input {
+  flex: 1;
+  border: none;
+  background: none;
+  outline: none;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--text);
+  min-width: 0;
+}
+
+.find-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.find-count {
+  flex-shrink: 0;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.find-nav-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.find-nav-btn:hover {
+  background: var(--bg-chrome, #EDECEA);
+  color: var(--text);
+}
+
+.find-toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.find-toggle-btn:hover,
+.find-toggle-btn.active {
+  background: var(--accent-soft, rgba(10,95,191,0.08));
+  color: var(--accent);
+}
+
+.find-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.find-close-btn:hover {
+  background: var(--bg-chrome, #EDECEA);
+  color: var(--text);
+}
+
+.find-action-btn {
+  background: none;
+  border: 1px solid var(--border-medium, rgba(0,0,0,0.12));
+  border-radius: 5px;
+  padding: 4px 10px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.find-action-btn:hover:not(:disabled) {
+  background: var(--bg-chrome, #EDECEA);
+}
+.find-action-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
 </style>

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -356,18 +356,18 @@ function toggleFocusMode() {
 function updateDocAbove() {
   const root = documentAreaRef.value
   if (!root) return
-  const pm = root.querySelector('.ProseMirror')
+  const pm = root.querySelector('.ProseMirror') as HTMLElement | null
   if (!pm) return
-  const rootTop = root.getBoundingClientRect().top
-  // A block is "above" when its bottom edge has cleared the top of the scroll area
-  // (with a small buffer so the last line of a heading stays visible as you cross it)
-  const threshold = rootTop + 48
-  Array.from(pm.children).forEach(el => {
-    const bottom = el.getBoundingClientRect().bottom
+  const rootRect = root.getBoundingClientRect()
+  // Dim blocks whose bottom enters the top 30 % of the scroll container viewport.
+  // ~200 px of scroll on a typical screen triggers the first fade.
+  const threshold = rootRect.top + rootRect.height * 0.3
+  Array.from(pm.children).forEach(child => {
+    const bottom = (child as HTMLElement).getBoundingClientRect().bottom
     if (bottom < threshold) {
-      el.classList.add('doc-above')
+      child.classList.add('doc-above')
     } else {
-      el.classList.remove('doc-above')
+      child.classList.remove('doc-above')
     }
   })
 }

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -6,9 +6,11 @@ import StarterKit from '@tiptap/starter-kit'
 import { CitationNode } from '../extensions/CitationNode'
 import { emitter } from '../events'
 import { useDocument, type BibEntry } from '../composables/useDocument'
+import { useFileOps } from '../composables/useFileOps'
 
 const router = useRouter()
 const { docTitle, docAuthors, citations, isDirty } = useDocument()
+const { openDocument, saveDocument } = useFileOps()
 
 // ── Editor ────────────────────────────────────────────────────────────────────
 
@@ -74,7 +76,29 @@ const activeCitation = ref<BibEntry | null>(null)
 
 // ── Event wiring ──────────────────────────────────────────────────────────────
 
+// ── Keyboard shortcuts ────────────────────────────────────────────────────────
+
+async function handleKeydown(e: KeyboardEvent) {
+  const ctrl = e.ctrlKey || e.metaKey
+  if (!ctrl) return
+  if (e.key === 's') {
+    e.preventDefault()
+    const content = editor.value?.getHTML() ?? ''
+    await saveDocument(content)
+  }
+  if (e.key === 'o') {
+    e.preventDefault()
+    const body = await openDocument()
+    if (body && editor.value) {
+      editor.value.commands.setContent(body)
+      isDirty.value = false
+    }
+  }
+}
+
 onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+
   emitter.on('cite:hover', ({ key, rect }) => {
     if (panelOpen.value) return
     cancelHide()
@@ -103,6 +127,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown)
   emitter.off('cite:hover')
   emitter.off('cite:leave')
   emitter.off('cite:click')

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -99,6 +99,14 @@ async function handleKeydown(e: KeyboardEvent) {
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
 
+  // Load content when a file is opened from the hamburger menu or file ops
+  emitter.on('doc:opened', ({ content }) => {
+    if (editor.value && content) {
+      editor.value.commands.setContent(content)
+      isDirty.value = false
+    }
+  })
+
   emitter.on('cite:hover', ({ key, rect }) => {
     if (panelOpen.value) return
     cancelHide()
@@ -128,6 +136,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKeydown)
+  emitter.off('doc:opened')
   emitter.off('cite:hover')
   emitter.off('cite:leave')
   emitter.off('cite:click')

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -425,7 +425,6 @@ function openOrcid(orcid: string) {
             :class="{ 'focus-active': focusMode }"
             @click="toggleFocusMode"
             :title="focusMode ? 'Exit focus mode (F11)' : 'Focus mode (F11)'"
-            style="margin-left: auto"
           >
             <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="7" cy="7" r="2.5"/>
@@ -752,28 +751,25 @@ function openOrcid(orcid: string) {
 .meta-trigger {
   background: none;
   border: none;
-  padding: 2px 4px;
+  padding: 3px 5px;
   cursor: pointer;
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
-  opacity: 0;
+  opacity: 0.55;
   transition: opacity var(--t), background var(--t), color var(--t);
 }
 
-.paper-eyebrow:hover .meta-trigger {
+.meta-trigger:hover {
   opacity: 1;
+  background: var(--bg-chrome-active);
+  color: var(--text-secondary);
 }
 
 .meta-trigger.focus-active {
   opacity: 1;
   color: var(--accent-purple, #7C3AED);
-}
-
-.meta-trigger:hover {
-  background: var(--bg-chrome-active);
-  color: var(--text-secondary);
 }
 
 .meta-trigger.focus-active:hover {

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import { CitationNode } from '../extensions/CitationNode'
+import { CitationSuggest } from '../extensions/CitationSuggest'
 import { emitter } from '../events'
 import { useDocument, type BibEntry } from '../composables/useDocument'
 import { useFileOps } from '../composables/useFileOps'
@@ -37,6 +38,7 @@ const editor = useEditor({
       code: false,
     }),
     CitationNode,
+    CitationSuggest,
   ],
   content: INITIAL_CONTENT,
   onUpdate() {

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -230,6 +230,7 @@ async function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     if (findOpen.value) { e.preventDefault(); closeFind(); return }
   }
+  if (e.key === 'F11') { e.preventDefault(); toggleFocusMode(); return }
   if (!ctrl) return
   if (e.key === 's') {
     e.preventDefault()
@@ -337,6 +338,48 @@ function removeAuthor(i: number) {
   docAuthors.value.splice(i, 1)
 }
 
+// ── Focus mode ────────────────────────────────────────────────────────────────
+
+const focusMode = ref(false)
+const documentAreaRef = ref<HTMLElement | null>(null)
+
+function toggleFocusMode() {
+  focusMode.value = !focusMode.value
+  if (focusMode.value) {
+    // Run once immediately so the current scroll position is reflected
+    updateDocAbove()
+  } else {
+    clearDocAbove()
+  }
+}
+
+function updateDocAbove() {
+  const root = documentAreaRef.value
+  if (!root) return
+  const pm = root.querySelector('.ProseMirror')
+  if (!pm) return
+  const rootTop = root.getBoundingClientRect().top
+  // A block is "above" when its bottom edge has cleared the top of the scroll area
+  // (with a small buffer so the last line of a heading stays visible as you cross it)
+  const threshold = rootTop + 48
+  Array.from(pm.children).forEach(el => {
+    const bottom = el.getBoundingClientRect().bottom
+    if (bottom < threshold) {
+      el.classList.add('doc-above')
+    } else {
+      el.classList.remove('doc-above')
+    }
+  })
+}
+
+function clearDocAbove() {
+  document.querySelectorAll('.doc-above').forEach(el => el.classList.remove('doc-above'))
+}
+
+function onDocScroll() {
+  if (focusMode.value) updateDocAbove()
+}
+
 // ── Byline helpers ────────────────────────────────────────────────────────────
 
 const uniqueAffiliations = computed(() => {
@@ -367,11 +410,28 @@ function openOrcid(orcid: string) {
 <template>
   <div class="write-layout">
     <!-- Document scroll area -->
-    <div class="document-area">
+    <div
+      class="document-area"
+      :class="{ 'focus-mode': focusMode }"
+      ref="documentAreaRef"
+      @scroll.passive="onDocScroll"
+    >
       <div class="paper">
         <!-- Paper header -->
         <div class="paper-eyebrow">
           <span>{{ docStatus }}{{ docDate ? ' · ' + docDate : '' }}</span>
+          <button
+            class="meta-trigger"
+            :class="{ 'focus-active': focusMode }"
+            @click="toggleFocusMode"
+            :title="focusMode ? 'Exit focus mode (F11)' : 'Focus mode (F11)'"
+            style="margin-left: auto"
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="7" cy="7" r="2.5"/>
+              <circle cx="7" cy="7" r="5.5" :stroke-opacity="focusMode ? 1 : 0.45"/>
+            </svg>
+          </button>
           <button class="meta-trigger" @click="openMeta" title="Edit document metadata">
             <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
               <path d="M8.5 1.5a1.414 1.414 0 0 1 2 2L3 11H1v-2L8.5 1.5z"/>
@@ -676,13 +736,17 @@ function openOrcid(orcid: string) {
 .paper-eyebrow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-size: 10.5px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--text-secondary);
   margin-bottom: 14px;
+}
+
+.paper-eyebrow > span {
+  flex: 1;
 }
 
 .meta-trigger {
@@ -702,9 +766,18 @@ function openOrcid(orcid: string) {
   opacity: 1;
 }
 
+.meta-trigger.focus-active {
+  opacity: 1;
+  color: var(--accent-purple, #7C3AED);
+}
+
 .meta-trigger:hover {
   background: var(--bg-chrome-active);
   color: var(--text-secondary);
+}
+
+.meta-trigger.focus-active:hover {
+  color: var(--accent-purple, #7C3AED);
 }
 
 .paper-title {

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -257,6 +257,8 @@ async function handleKeydown(e: KeyboardEvent) {
 
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
+  // Imperative scroll listener — more reliable than @scroll on the template ref
+  documentAreaRef.value?.addEventListener('scroll', onDocScroll, { passive: true })
 
   // Load content when a file is opened from the hamburger menu or file ops
   emitter.on('doc:opened', ({ content }) => {
@@ -295,6 +297,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKeydown)
+  documentAreaRef.value?.removeEventListener('scroll', onDocScroll)
   emitter.off('doc:opened')
   emitter.off('cite:hover')
   emitter.off('cite:leave')
@@ -346,34 +349,39 @@ const documentAreaRef = ref<HTMLElement | null>(null)
 function toggleFocusMode() {
   focusMode.value = !focusMode.value
   if (focusMode.value) {
-    // Run once immediately so the current scroll position is reflected
     updateDocAbove()
   } else {
     clearDocAbove()
   }
 }
 
+function getProseMirror(): HTMLElement | null {
+  return documentAreaRef.value?.querySelector('.ProseMirror') as HTMLElement | null
+}
+
 function updateDocAbove() {
   const root = documentAreaRef.value
-  if (!root) return
-  const pm = root.querySelector('.ProseMirror') as HTMLElement | null
-  if (!pm) return
+  const pm = getProseMirror()
+  if (!root || !pm) return
   const rootRect = root.getBoundingClientRect()
-  // Dim blocks whose bottom enters the top 30 % of the scroll container viewport.
-  // ~200 px of scroll on a typical screen triggers the first fade.
+  // Fade blocks whose bottom crosses into the top 30% of the scroll container.
   const threshold = rootRect.top + rootRect.height * 0.3
   Array.from(pm.children).forEach(child => {
-    const bottom = (child as HTMLElement).getBoundingClientRect().bottom
-    if (bottom < threshold) {
-      child.classList.add('doc-above')
-    } else {
-      child.classList.remove('doc-above')
-    }
+    const el = child as HTMLElement
+    const below = el.getBoundingClientRect().bottom >= threshold
+    el.style.opacity = below ? '' : '0.2'
+    el.style.transition = 'opacity 0.4s ease'
   })
 }
 
 function clearDocAbove() {
-  document.querySelectorAll('.doc-above').forEach(el => el.classList.remove('doc-above'))
+  const pm = getProseMirror()
+  if (!pm) return
+  Array.from(pm.children).forEach(child => {
+    const el = child as HTMLElement
+    el.style.opacity = ''
+    el.style.transition = ''
+  })
 }
 
 function onDocScroll() {
@@ -414,7 +422,6 @@ function openOrcid(orcid: string) {
       class="document-area"
       :class="{ 'focus-mode': focusMode }"
       ref="documentAreaRef"
-      @scroll.passive="onDocScroll"
     >
       <div class="paper">
         <!-- Paper header -->

--- a/src/views/WriteView.vue
+++ b/src/views/WriteView.vue
@@ -1,100 +1,125 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
+import { useEditor, EditorContent } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+import { CitationNode } from '../extensions/CitationNode'
+import { emitter } from '../events'
+import { useDocument, type BibEntry } from '../composables/useDocument'
 
 const router = useRouter()
+const { docTitle, docAuthors, citations, isDirty } = useDocument()
 
-interface Citation {
-  id: number
-  title: string
-  authors: string
-  year: string
-  journal: string
-  doi: string
-  abstract: string
-  yourNotes: string
-}
+// ── Editor ────────────────────────────────────────────────────────────────────
 
-const citations: Citation[] = [
-  {
-    id: 1,
-    title: 'Allergen Labelling Compliance in Food Manufacturing: A Systematic Review',
-    authors: 'Popova, M., Chen, L., & Okafor, R.',
-    year: '2022',
-    journal: 'Food Control',
-    doi: '10.1016/j.foodcont.2022.108940',
-    abstract: 'A systematic review examining allergen labelling compliance across 14 countries. Of 847 products sampled, 34% showed discrepancies between declared allergens and actual ingredient lists, with peanut and tree nut labelling showing the highest non-compliance rates. The study identifies inconsistent definition of precautionary labelling as a primary driver of consumer confusion.',
-    yourNotes: 'Key stat for RQ2 — cross-check with FSSAI thresholds. The 34% figure is pre-pandemic; useful as baseline. Check methodology section for sampling frame before citing directly.',
+const INITIAL_CONTENT = `
+<h2>Abstract</h2>
+<p>The inadequate labelling of allergens in packaged foods poses significant public health risks, particularly for the estimated 220–520 million people globally affected by food allergies. This cross-sectional study examines allergen labelling compliance among packaged food manufacturers in India under the Food Safety and Standards (Labelling and Display) Regulations 2020, with comparative reference to EU Regulation 1169/2011 and the US FALCPA. We find systematic gaps in precautionary labelling practice and identify regulatory interpretation as a primary source of non-compliance.</p>
+<h2>1. Introduction</h2>
+<p>Food allergy affects an estimated 1 in 8 consumers <span data-cite-key="fda2021" data-index="2"></span> in developed markets, with rising prevalence documented across South Asian populations. Despite regulatory frameworks mandating allergen disclosure, recent systematic reviews indicate that approximately 34% of packaged food products <span data-cite-key="popova2022" data-index="1"></span> show discrepancies between declared allergen content and actual ingredient composition.</p>
+<p>In the Indian context, the FSSAI has established a threshold of 10 mg/kg for individual allergen declarations under §4.2.1 of the 2020 labelling regulations <span data-cite-key="hadley2019" data-index="3"></span> yet enforcement mechanisms remain inconsistently applied across food category segments.</p>
+<p>The foundational challenge is not merely one of regulatory compliance, but of communication design: precautionary allergen labels such as "may contain" are routinely misinterpreted by consumers, <span data-cite-key="hadley2019" data-index="3"></span> undermining their protective function even where they are accurately applied.</p>
+<h2>2. Literature Review</h2>
+<p>The landscape of allergen labelling research is characterised by a tension between regulatory prescription and real-world consumer behaviour. Foundational work by Hadley &amp; King (2019) <span data-cite-key="hadley2019" data-index="3"></span> established baseline comprehension rates for precautionary labelling across demographically stratified cohorts, finding that education level and prior allergy diagnosis are the primary moderators of label interpretation accuracy.</p>
+<p>Subsequent systematic review of manufacturing-side compliance by Popova et al. (2022) <span data-cite-key="popova2022" data-index="1"></span> extended this analysis to the supply chain, demonstrating that discrepancies originate as frequently in ingredient sourcing and cross-contact risk management as in the labelling design itself.</p>
+<h2>3. Methods</h2>
+<p>Cross-sectional analysis of n=340 SKUs sampled from organised retail in three Indian metro markets (Chennai, Pune, Hyderabad). Audit conducted against FSSAI 2020 labelling regulations with comparative coding against EU and US frameworks. Inter-rater reliability: κ = 0.87. [Draft continues…]</p>
+`
+
+const editor = useEditor({
+  extensions: [
+    StarterKit.configure({
+      heading: { levels: [2, 3] },
+      horizontalRule: false,
+      codeBlock: false,
+      code: false,
+    }),
+    CitationNode,
+  ],
+  content: INITIAL_CONTENT,
+  onUpdate() {
+    isDirty.value = true
   },
-  {
-    id: 2,
-    title: 'Food Allergen Labeling and Consumer Protection Act: Compliance Report 2021',
-    authors: 'U.S. Food and Drug Administration',
-    year: '2021',
-    journal: 'FDA Technical Report',
-    doi: 'FDA-TR-2021-0042',
-    abstract: 'Annual compliance report on FALCPA implementation, documenting a 1-in-8 consumer experience with allergic reactions attributable to labelling failures in packaged foods over a 24-month surveillance period. Survey conducted across n=12,400 households with at least one member reporting a food allergy.',
-    yourNotes: 'The 1-in-8 statistic is from their consumer survey (n=12,400), not clinical data. Worth footnoting. Good for introduction to establish scale of the problem.',
-  },
-  {
-    id: 3,
-    title: 'Hidden Allergens and Precautionary Labelling: Consumer Understanding and Risk',
-    authors: 'Hadley, C. & King, J.',
-    year: '2019',
-    journal: 'J Allergy Clin Immunol',
-    doi: '10.1016/j.jaci.2018.11.025',
-    abstract: 'Cross-sectional study of consumer comprehension of precautionary allergen labels (PAL) across a 2019 baseline cohort. Finds significant variation in PAL interpretation by education level and prior allergy diagnosis. 67% of respondents misinterpreted "may contain" as indicating lower risk than a direct ingredient declaration.',
-    yourNotes: 'Foundational paper for our literature review section. The "may contain" framing discussion is directly applicable to our FSSAI policy recommendations.',
-  },
-]
+})
+
+// ── Tooltip state ─────────────────────────────────────────────────────────────
 
 const tooltipVisible = ref(false)
-const tooltipCitation = ref<Citation | null>(null)
+const tooltipCitation = ref<BibEntry | null>(null)
 const tooltipStyle = ref({ left: '0px', top: '0px' })
-
-const panelOpen = ref(false)
-const activeCitation = ref<Citation | null>(null)
-
+const tooltipHovered = ref(false)
 let hideTimer: ReturnType<typeof setTimeout> | null = null
 
-function showTooltip(e: MouseEvent, id: number) {
-  if (panelOpen.value) return
-  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
-  const el = e.currentTarget as HTMLElement
-  const rect = el.getBoundingClientRect()
-  tooltipStyle.value = {
-    left: `${rect.left + rect.width / 2}px`,
-    top: `${rect.bottom + 10}px`,
-  }
-  tooltipCitation.value = citations.find(c => c.id === id) ?? null
-  tooltipVisible.value = true
+function findCitation(key: string) {
+  return citations.value.find(c => c.key === key) ?? null
 }
 
-function startHideTooltip() {
+function startHide() {
   hideTimer = setTimeout(() => {
+    if (!tooltipHovered.value) {
+      tooltipVisible.value = false
+      tooltipCitation.value = null
+    }
+  }, 200)
+}
+
+function cancelHide() {
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
+}
+
+// ── Citation panel state ──────────────────────────────────────────────────────
+
+const panelOpen = ref(false)
+const activeCitation = ref<BibEntry | null>(null)
+
+// ── Event wiring ──────────────────────────────────────────────────────────────
+
+onMounted(() => {
+  emitter.on('cite:hover', ({ key, rect }) => {
+    if (panelOpen.value) return
+    cancelHide()
+    const cite = findCitation(key)
+    if (!cite) return
+    tooltipStyle.value = {
+      left: `${rect.left + rect.width / 2}px`,
+      top: `${rect.bottom + 10}px`,
+    }
+    tooltipCitation.value = cite
+    tooltipVisible.value = true
+  })
+
+  emitter.on('cite:leave', () => {
+    startHide()
+  })
+
+  emitter.on('cite:click', ({ key }) => {
+    cancelHide()
     tooltipVisible.value = false
-    tooltipCitation.value = null
-  }, 180)
-}
+    const cite = findCitation(key)
+    if (!cite) return
+    activeCitation.value = cite
+    panelOpen.value = true
+  })
+})
 
-function cancelHideTooltip() {
-  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
-}
-
-function openPanel(id: number) {
-  tooltipVisible.value = false
-  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
-  activeCitation.value = citations.find(c => c.id === id) ?? null
-  panelOpen.value = true
-}
-
-function openTooltipCitation() {
-  if (tooltipCitation.value) openPanel(tooltipCitation.value.id)
-}
+onBeforeUnmount(() => {
+  emitter.off('cite:hover')
+  emitter.off('cite:leave')
+  emitter.off('cite:click')
+  editor.value?.destroy()
+  if (hideTimer) clearTimeout(hideTimer)
+})
 
 function closePanel() {
   panelOpen.value = false
   setTimeout(() => { activeCitation.value = null }, 260)
+}
+
+function openTooltipCitation() {
+  if (!tooltipCitation.value) return
+  activeCitation.value = tooltipCitation.value
+  tooltipVisible.value = false
+  panelOpen.value = true
 }
 
 function goToPdf() {
@@ -104,95 +129,29 @@ function goToPdf() {
 
 <template>
   <div class="write-layout">
-    <!-- Document scrollable area -->
+    <!-- Document scroll area -->
     <div class="document-area">
       <div class="paper">
-        <!-- Paper header -->
+        <!-- Paper header — mirrors placeholder exactly -->
         <div class="paper-eyebrow">Working Draft · April 2026</div>
-        <h1 class="paper-title">Allergen Labelling in Packaged Foods</h1>
+        <h1 class="paper-title">{{ docTitle }}</h1>
         <p class="paper-subtitle">A Cross-Sectional Study of FSSAI Compliance and Consumer Risk Communication</p>
         <div class="paper-byline">
-          <span>Sharma, R.</span>
-          <span class="by-sep">·</span>
-          <span>[Author]</span>
+          <template v-for="(author, i) in docAuthors" :key="i">
+            <span>{{ author }}</span>
+            <span v-if="i < docAuthors.length - 1" class="by-sep">·</span>
+          </template>
           <span class="by-sep">·</span>
           <span>Food Policy Studies, IIT Madras</span>
         </div>
         <div class="paper-rule"></div>
 
-        <!-- Abstract -->
-        <div class="paper-section">
-          <h2 class="section-head">Abstract</h2>
-          <p>The inadequate labelling of allergens in packaged foods poses significant public health risks, particularly for the estimated 220–520 million people globally affected by food allergies. This cross-sectional study examines allergen labelling compliance among packaged food manufacturers in India under the Food Safety and Standards (Labelling and Display) Regulations 2020, with comparative reference to EU Regulation 1169/2011 and the US FALCPA. We find systematic gaps in precautionary labelling practice and identify regulatory interpretation as a primary source of non-compliance.</p>
-        </div>
-
-        <!-- Introduction -->
-        <div class="paper-section">
-          <h2 class="section-head">1. Introduction</h2>
-          <p>Food allergy affects an estimated
-            <span
-              class="cite-inline"
-              @mouseenter="showTooltip($event, 2)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(2)"
-            >1 in 8 consumers<sup class="cite-sup">[2]</sup></span>
-            in developed markets, with rising prevalence documented across South Asian populations. Despite regulatory frameworks mandating allergen disclosure, recent systematic reviews indicate that approximately
-            <span
-              class="cite-inline"
-              @mouseenter="showTooltip($event, 1)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(1)"
-            >34% of packaged food products<sup class="cite-sup">[1]</sup></span>
-            show discrepancies between declared allergen content and actual ingredient composition.
-          </p>
-          <p>In the Indian context, the FSSAI has established a threshold of 10 mg/kg for individual allergen declarations under §4.2.1 of the 2020 labelling regulations,<sup
-              class="cite-sup cite-sup-bare"
-              @mouseenter="showTooltip($event, 3)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(3)"
-            >[3]</sup> yet enforcement mechanisms remain inconsistently applied across food category segments.
-          </p>
-          <p>The foundational challenge is not merely one of regulatory compliance, but of communication design: precautionary allergen labels such as "may contain" are routinely misinterpreted by consumers,<sup
-              class="cite-sup cite-sup-bare"
-              @mouseenter="showTooltip($event, 3)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(3)"
-            >[3]</sup> undermining their protective function even where they are accurately applied.
-          </p>
-        </div>
-
-        <!-- Literature Review -->
-        <div class="paper-section">
-          <h2 class="section-head">2. Literature Review</h2>
-          <p>The landscape of allergen labelling research is characterised by a tension between regulatory prescription and real-world consumer behaviour. Foundational work by
-            <span
-              class="cite-inline"
-              @mouseenter="showTooltip($event, 3)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(3)"
-            >Hadley &amp; King (2019)<sup class="cite-sup">[3]</sup></span>
-            established baseline comprehension rates for precautionary labelling across demographically stratified cohorts, finding that education level and prior allergy diagnosis are the primary moderators of label interpretation accuracy.
-          </p>
-          <p>Subsequent systematic review of manufacturing-side compliance by
-            <span
-              class="cite-inline"
-              @mouseenter="showTooltip($event, 1)"
-              @mouseleave="startHideTooltip"
-              @click="openPanel(1)"
-            >Popova et al. (2022)<sup class="cite-sup">[1]</sup></span>
-            extended this analysis to the supply chain, demonstrating that discrepancies originate as frequently in ingredient sourcing and cross-contact risk management as in the labelling design itself. This has significant implications for how regulatory bodies frame compliance obligations.
-          </p>
-        </div>
-
-        <!-- Methods (partial) -->
-        <div class="paper-section">
-          <h2 class="section-head">3. Methods</h2>
-          <p class="text-secondary-col">Cross-sectional analysis of n=340 SKUs sampled from organised retail in three Indian metro markets (Chennai, Pune, Hyderabad). Audit conducted against FSSAI 2020 labelling regulations with comparative coding against EU and US frameworks. Inter-rater reliability: κ = 0.87. [Draft continues…]</p>
-        </div>
+        <!-- Tiptap editor — content starts from Abstract -->
+        <EditorContent :editor="editor" class="editor-body" />
       </div>
     </div>
 
-    <!-- Citation Panel (slide in) -->
+    <!-- Citation panel (slide in) -->
     <Transition name="panel">
       <div class="citation-panel" v-if="panelOpen">
         <div class="cp-header">
@@ -213,11 +172,7 @@ function goToPdf() {
           </div>
           <div class="cp-block">
             <div class="cp-block-label">Abstract</div>
-            <p class="cp-abstract">{{ activeCitation.abstract }}</p>
-          </div>
-          <div class="cp-block cp-notes">
-            <div class="cp-block-label">Your notes</div>
-            <p class="cp-notes-text">{{ activeCitation.yourNotes }}</p>
+            <p class="cp-abstract">{{ activeCitation.abstractText }}</p>
           </div>
           <button class="cp-detail-btn" @click="goToPdf">
             View in Detail
@@ -230,19 +185,19 @@ function goToPdf() {
     </Transition>
   </div>
 
-  <!-- Tooltip (teleported to body so it clears all z-index contexts) -->
+  <!-- Tooltip -->
   <Teleport to="body">
     <div
       class="cite-tooltip"
       v-show="tooltipVisible && tooltipCitation"
       :style="tooltipStyle"
-      @mouseenter="cancelHideTooltip"
-      @mouseleave="startHideTooltip"
+      @mouseenter="tooltipHovered = true; cancelHide()"
+      @mouseleave="tooltipHovered = false; startHide()"
     >
       <template v-if="tooltipCitation">
         <div class="tt-title">{{ tooltipCitation.title }}</div>
         <div class="tt-authors">{{ tooltipCitation.authors }} · {{ tooltipCitation.year }}</div>
-        <div class="tt-excerpt">{{ tooltipCitation.abstract.slice(0, 130) }}…</div>
+        <div class="tt-excerpt">{{ (tooltipCitation.abstractText ?? '').slice(0, 130) }}…</div>
         <button class="tt-cta" @click="openTooltipCitation">View in detail →</button>
       </template>
     </div>
@@ -256,7 +211,6 @@ function goToPdf() {
   overflow: hidden;
 }
 
-/* Document scroll area */
 .document-area {
   flex: 1;
   overflow-y: auto;
@@ -267,7 +221,6 @@ function goToPdf() {
   min-width: 0;
 }
 
-/* The "paper" card */
 .paper {
   width: 100%;
   max-width: 660px;
@@ -326,70 +279,11 @@ function goToPdf() {
   margin-bottom: 28px;
 }
 
-.paper-section {
-  margin-bottom: 28px;
+.editor-body {
+  /* EditorContent fills remaining space; ProseMirror styled in editor.css */
 }
 
-.section-head {
-  font-family: var(--font-ui);
-  font-size: 10.5px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.09em;
-  color: var(--text-tertiary);
-  margin-bottom: 10px;
-}
-
-.paper-section p {
-  font-family: var(--font-doc);
-  font-size: 15.5px;
-  line-height: 1.8;
-  color: var(--text);
-  margin-bottom: 14px;
-}
-
-.paper-section p:last-child {
-  margin-bottom: 0;
-}
-
-.text-secondary-col {
-  color: var(--text-secondary) !important;
-}
-
-/* Inline citation spans */
-.cite-inline {
-  cursor: pointer;
-  transition: color var(--t);
-}
-
-.cite-inline:hover .cite-sup {
-  background: var(--accent-soft);
-  border-radius: 2px;
-}
-
-.cite-sup {
-  color: var(--accent);
-  font-family: var(--font-ui);
-  font-size: 9.5px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  padding: 0 1.5px;
-  border-radius: 2px;
-  cursor: pointer;
-  transition: background var(--t);
-  vertical-align: super;
-  line-height: 0;
-}
-
-.cite-sup-bare {
-  cursor: pointer;
-}
-.cite-sup-bare:hover {
-  background: var(--accent-soft);
-  border-radius: 2px;
-}
-
-/* Citation Panel */
+/* Citation panel — identical to placeholder */
 .citation-panel {
   width: 336px;
   flex-shrink: 0;
@@ -400,7 +294,7 @@ function goToPdf() {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.06);
+  box-shadow: -4px 0 20px rgba(0,0,0,0.06);
 }
 
 .cp-header {
@@ -499,20 +393,6 @@ function goToPdf() {
   color: var(--text-secondary);
 }
 
-.cp-notes {
-  background: rgba(10, 95, 191, 0.05);
-  border-radius: var(--radius);
-  padding: 11px 12px;
-  border: 1px solid rgba(10, 95, 191, 0.1);
-}
-
-.cp-notes-text {
-  font-size: 12.5px;
-  line-height: 1.6;
-  color: var(--text);
-  font-style: italic;
-}
-
 .cp-detail-btn {
   display: flex;
   align-items: center;
@@ -532,7 +412,6 @@ function goToPdf() {
 }
 .cp-detail-btn:hover { opacity: 0.86; }
 
-/* Panel Transition */
 .panel-enter-active,
 .panel-leave-active {
   transition: transform var(--t), opacity var(--t);
@@ -544,16 +423,16 @@ function goToPdf() {
 }
 </style>
 
-<!-- Global tooltip styles — not scoped because it's teleported to body -->
+<!-- Tooltip global styles — not scoped, teleported to body -->
 <style>
 .cite-tooltip {
   position: fixed;
   transform: translateX(-50%);
   z-index: 9999;
-  background: rgba(255, 255, 255, 0.97);
+  background: rgba(255,255,255,0.97);
   backdrop-filter: blur(28px);
   -webkit-backdrop-filter: blur(28px);
-  border: 1px solid rgba(0, 0, 0, 0.09);
+  border: 1px solid rgba(0,0,0,0.09);
   border-radius: 10px;
   box-shadow: 0 8px 32px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06);
   padding: 14px 15px;
@@ -593,10 +472,7 @@ function goToPdf() {
   color: #0A5FBF;
   cursor: pointer;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  letter-spacing: -0.01em;
 }
 
-.tt-cta:hover {
-  text-decoration: underline;
-}
+.tt-cta:hover { text-decoration: underline; }
 </style>


### PR DESCRIPTION
## Summary

- Full SQLite-backed library (collections, tags, DOI/arXiv/ISBN fetch, .bib import/export, PDF attachments)
- Real PDF viewer with pdfjs-dist, text highlight annotations stored in SQLite
- Editor extensions: math (KaTeX), section cross-refs, find/replace, heading auto-numbering, focus mode (F11)
- Annotations view: cross-source searchable list, grouped by source, inline note editing, click → opens PDF at page
- Metadata panel, hamburger menu, recent files

## Test plan

- [ ] Library: add item via DOI fetch, attach a PDF, open in viewer
- [ ] PDF viewer: highlight text → annotation created, visible in Annotations tab
- [ ] Annotations view: search filters by text/author/title, group toggle works, click opens correct PDF page
- [ ] Editor: `@` cite autocomplete, `##` section ref, math blocks, F11 focus mode, Ctrl+F find

🤖 Generated with [Claude Code](https://claude.com/claude-code)